### PR TITLE
Add course scaffold, community files, and prompt resources

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a problem with the course material
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+- OS: [e.g. Windows, macOS]
+- Browser [e.g. Chrome, Safari]
+- Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this course
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+- 
+
+## Testing
+- [ ] `npm test`
+
+## Checklist
+- [ ] Documentation updated
+- [ ] Ready for review

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,11 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Additional ignores
+.DS_Store
+Thumbs.db
+__pycache__/
+*.pyc
+.env
+venv/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) Code of Conduct.
+
+## Our Pledge
+We pledge to make participation in our project and community a harassment-free experience for everyone.
+
+## Our Standards
+- Use welcoming and inclusive language.
+- Be respectful of differing viewpoints and experiences.
+- Gracefully accept constructive criticism.
+- Focus on what is best for the community.
+- Show empathy toward other community members.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [support@timothywarner.org](mailto:support@timothywarner.org). All complaints will be reviewed and investigated promptly.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant][homepage].
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Thanks for your interest in contributing! We welcome improvements, fixes, and suggestions.
+
+## How to Contribute
+1. Fork the repository and create your branch from `main`.
+2. Make your changes and ensure your code follows the course style.
+3. Run any available tests and ensure they pass.
+4. Submit a pull request with a clear description of your changes.
+
+## Reporting Issues
+Use the issue templates provided to report bugs or request features. Please search existing issues before opening a new one.
+
+## Code of Conduct
+By participating in this project, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,82 @@
-# prompt-pro
-How to Prompt Like a Pro Course Repo for Tim's O'Reilly Live Learning class
+# How to Prompt Like a Pro
+
+Master AI prompting to accelerate business innovation, productivity, and decision-making.
+
+![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)
+![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
+
+## About This Course
+Generative AI is already reshaping how we work. This live training shows business professionals how to communicate clearly with AI systems and extract tangible value from tools like Microsoft Copilot, OpenAI ChatGPT, Google Gemini, and Anthropic Claude.
+
+## Learning Outcomes
+By the end of the course you'll understand:
+- How prompt engineering directly improves your business outcomes with AI
+- Which prompt-writing techniques deliver the best results in real-world tasks
+- How to avoid common prompt pitfalls that waste time or limit usefulness
+
+And you'll be able to:
+- Write clear, useful prompts quickly and confidently
+- Improve the accuracy and reliability of AI-generated business content
+- Integrate effective prompt practices into your daily work using the best tools for the job
+
+## Who Should Attend
+- Business professionals seeking more practical value from AI
+- Regular users of AI tools for writing, analysis, marketing, or management
+- Anyone who needs straightforward strategies to improve AI-generated results immediately
+
+## Prerequisites
+- Basic familiarity with tools like ChatGPT or Bing Chat
+- No coding or deep technical background required
+
+## Course Setup
+- Internet connection
+- Google account
+- Free accounts for ChatGPT (required) and optional services like Google Gemini, NotebookLM, Claude, and Midjourney
+
+## Course Plan
+Each segment runs approximately 50 minutes with time for Q&A.
+
+### Segment 1: Core Prompting Skills for Reliable AI Results
+- Essential prompt-writing techniques proven across industries
+- Common prompt pitfalls and how to avoid them
+- Evergreen, reusable prompt recipes to improve AI responses immediately
+
+### Segment 2: Multimodal Prompting—Beyond Text
+- Writing effective prompts for ChatGPT Vision, Sora, and Midjourney
+- Quick-win visual prompting formulas you can reuse immediately
+- Prompting methods for presentations, marketing materials, medical imagery, and legal visuals
+
+### Segment 3: AI Notebooks for Better Insights and Decisions
+- NotebookLM, ChatGPT, and Claude workflows
+- Prompting for clearer analysis and reporting in business, healthcare, government, and legal contexts
+- Hands-on notebook prompting you can use today
+
+### Segment 4: Advanced Prompting and Agentic AI
+- Automation with GitHub Copilot, Cursor, Windsurf, and Cline
+- Applying Retrieval-Augmented Generation (RAG) and Model Context Protocol (MCP)
+- Practical strategies for reliable, hallucination-free results and an agentic AI demo
+
+## Recommended Preparation
+- Read: [Quick Start Guide to Large Language Models: Strategies and Best Practices for Using ChatGPT and Other LLMs](https://learning.oreilly.com/library/view/-/9780138199425/)
+- Read: [The AI Revolution in Medicine: GPT-4 and Beyond](https://learning.oreilly.com/library/view/-/9780138200145/)
+
+## Recommended Follow-up
+- Read: [Beyond the Algorithm: AI, Security, Privacy, and Ethics](https://learning.oreilly.com/library/view/-/9780138268442/)
+- Read: [Responsible AI: Best Practices for Creating Trustworthy AI Systems](https://learning.oreilly.com/library/view/-/9780138073947/)
+
+## Prompting Resources
+- [Real-world prompting examples](resources/examples/real-world-prompts.md)
+- [Prompting frameworks and templates](resources/frameworks.md)
+- Free guides
+  - [DAIR.AI Prompting Introduction](resources/guides/dair-ai/prompts-intro.md)
+  - [DAIR.AI Prompts Advanced Usage](resources/guides/dair-ai/prompts-advanced-usage.md)
+  - [OpenAI Cookbook: Techniques to Improve Reliability](resources/guides/openai-cookbook/techniques-to-improve-reliability.md)
+
+## Contributing
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute.
+
+## Code of Conduct
+Participation in this project is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+This project is licensed under the [MIT License](LICENSE).

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,10 @@
+# Resources
+
+This directory collects free prompt engineering references for learners.
+
+- `guides/dair-ai` – content from [dair-ai/Prompt-Engineering-Guide](https://github.com/dair-ai/Prompt-Engineering-Guide) (MIT License)
+- `guides/openai-cookbook` – content from [openai/openai-cookbook](https://github.com/openai/openai-cookbook) (MIT License)
+- `examples/real-world-prompts.md` – practical prompts with explanations
+- `frameworks.md` – prompting frameworks, acronyms, and templates
+
+Third-party materials retain their original licenses inside their subfolders.

--- a/resources/examples/real-world-prompts.md
+++ b/resources/examples/real-world-prompts.md
@@ -1,0 +1,47 @@
+# Real-World Prompting Examples and Best Practices
+
+These examples show how to craft effective prompts for common business tasks. Adjust names, products, or domains to fit your needs.
+
+## Marketing Email
+```
+You are an experienced marketing copywriter.
+Write a 150-word launch email for our new cloud backup service, highlighting ease of use and first-year discount.
+Use an upbeat, professional tone and include a clear call to action.
+```
+**Why it works:** Sets role, specifies length, tone, and key points.
+
+## Data Analysis Summary
+```
+You are a data analyst.
+Summarize the key findings from the following sales CSV:
+<attach CSV data>
+Provide three bullet points and note any anomalies.
+```
+**Why it works:** Supplies context and desired format, invites anomaly detection.
+
+## Policy Drafting
+```
+Act as a human resources specialist.
+Draft a remote work policy for a 50-person tech startup.
+Outline expectations, security requirements, and communication norms.
+Limit the response to 200 words.
+```
+**Why it works:** Defines role, scope, and length, yielding concise policies.
+
+## Meeting Agenda Generator
+```
+You are an executive assistant.
+Create a 30-minute agenda for a quarterly planning meeting with the following topics:
+- budget review
+- product roadmap
+- staffing needs
+Use a table with columns for time, topic, and owner.
+```
+**Why it works:** Lists agenda items and output format for quick use.
+
+## Best Practices Recap
+- Provide context, role, and objective
+- Specify format, tone, and length
+- Include examples or data when helpful
+- Iterate and refine prompts based on responses
+

--- a/resources/frameworks.md
+++ b/resources/frameworks.md
@@ -1,0 +1,25 @@
+# Prompting Frameworks and Templates
+
+Acronyms and patterns help structure prompts quickly.
+
+## CRAFT
+**C**ontext, **R**ole, **A**ction, **F**ormat, **T**one.
+- *Template:* "You are a {role}. {Action}. Respond in {format} with a {tone} tone. Context: {context}."
+- *Link:* [CRAFT Prompting](https://github.com/microsoft/promptflow/tree/main/docs/prompt-engineering#craft)
+
+## CLEAR
+**C**ontext, **L**ength, **E**xamples, **A**nswer format, **R**efine.
+- *Template:* "Given {context}, provide {answer format} in about {length}. Examples: {examples}. Then refine the answer if needed."
+- *Link:* [CLEAR Framework](https://learnprompting.org/docs/prompt_frameworks/clear)
+
+## RAPID
+**R**ole, **A**ction, **P**arameters, **I**nput data, **D**esired format.
+- *Template:* "You are a {role}. Using {input data}, {action}. Parameters: {parameters}. Output {desired format}."
+- *Link:* [RAPID Prompting](https://promptingguide.ai/frameworks/rapid)
+
+## TAPE
+**T**ask, **A**ction, **P**arameters, **E**xamples.
+- *Template:* "Task: {task}. Action: {action}. Parameters: {parameters}. Examples: {examples}."
+- *Link:* [TAPE Technique](https://github.com/dair-ai/Prompt-Engineering-Guide)
+
+Use these structures as starting points and adapt them to your domain and objectives.

--- a/resources/guides/dair-ai/LICENSE
+++ b/resources/guides/dair-ai/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 DAIR.AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/resources/guides/dair-ai/prompts-advanced-usage.md
+++ b/resources/guides/dair-ai/prompts-advanced-usage.md
@@ -1,0 +1,419 @@
+# Advanced Prompting
+By this point, it should be obvious that it helps to improve prompts to get better results on different tasks. That's the whole idea behind prompt engineering. 
+
+While those examples were fun, let's cover a few concepts more formally before we jump into more advanced concepts. 
+
+Topics:
+
+- [Zero-shot Prompting](#zero-shot-prompting)
+- [Few-shot Prompting](#few-shot-prompting)
+- [Chain-of-Thought Prompting](#chain-of-thought-prompting)
+- [Zero-shot CoT](#zero-shot-cot)
+- [Self-Consistency](#self-consistency)
+- [Generate Knowledge Prompting](#generated-knowledge-prompting)
+- [Automatic Prompt Engineer](#automatic-prompt-engineer-ape)
+
+---
+## Zero-Shot Prompting
+LLMs today trained on large amounts of data and tuned to follow instructions, are capable of performing tasks zero-shot. We tried a few zero-shot examples in the previous section. Here is one of the examples we used:
+
+*Prompt:*
+```
+Classify the text into neutral, negative, or positive. 
+
+Text: I think the vacation is okay.
+Sentiment:
+```
+
+*Output:*
+```
+Neutral
+```
+
+Note that in the prompt above we didn't provide the model with any examples -- that's the zero-shot capabilities at work. When zero-shot doesn't work, it's recommended to provide demonstrations or examples in the prompt. Below we discuss the approach known as few-shot prompting.
+
+---
+## Few-Shot Prompting
+
+While large-language models already demonstrate remarkable zero-shot capabilities, they still fall short on more complex tasks when using the zero-shot setting. To improve on this, few-shot prompting is used as a technique to enable in-context learning where we provide demonstrations in the prompt to steer the model to better performance. The demonstrations serve as conditioning for subsequent examples where we would like the model to generate a response. 
+
+Let's demonstrate few-shot prompting via an example that was presented by [Brown et al. 2020](https://arxiv.org/abs/2005.14165). In the example, the task is to correctly use a new word in a sentence.
+
+*Prompt:*
+```
+A "whatpu" is a small, furry animal native to Tanzania. An example of a sentence that uses
+the word whatpu is:
+We were traveling in Africa and we saw these very cute whatpus.
+To do a "farduddle" means to jump up and down really fast. An example of a sentence that uses
+the word farduddle is:
+```
+
+*Output:*
+```
+When we won the game, we all started to farduddle in celebration.
+```
+
+We can observe that the model has somehow learned how to perform the task by providing it with just one example (i.e., 1-shot). For more difficult tasks, we can experiment with increasing the demonstrations (e.g., 3-shot, 5-shot, 10-shot, etc.). 
+
+Following the findings from [Min et al. (2022)](https://arxiv.org/abs/2202.12837), here are a few more tips about demonstrations/exemplars when doing few-shot:
+
+- "the label space and the distribution of the input text specified by the demonstrations are both important (regardless of whether the labels are correct for individual inputs)"
+- the format you use also plays a key role in performance, even if you just use random labels, this is much better than no labels at all.  
+- additional results show that selecting random labels from a true distribution of labels (instead of a uniform distribution) also helps.
+
+Let's try out a few examples. Let's first try an example with random labels (meaning the labels Negative and Positive are randomly assigned to the inputs):
+
+*Prompt:*
+```
+This is awesome! // Negative
+This is bad! // Positive
+Wow that movie was rad! // Positive
+What a horrible show! //
+```
+
+*Output:*
+```
+Negative
+```
+
+We still get the correct answer, even though the labels have been randomized. Note that we also kept the format, which helps too. In fact, with further experimentation, it seems the newer GPT models we are experimenting with are becoming more robust to even random formats. Example:
+
+*Prompt:*
+```
+Positive This is awesome! 
+This is bad! Negative
+Wow that movie was rad!
+Positive
+What a horrible show! --
+```
+
+*Output:*
+```
+Negative
+```
+
+There is no consistency in the format above but the model still predicted the correct label. We have to conduct a more thorough analysis to confirm if this holds for different and more complex tasks, including different variations of prompts.
+
+### Limitations of Few-shot Prompting
+
+Standard few-shot prompting works well for many tasks but is still not a perfect technique, especially when dealing with more complex reasoning tasks. Let's demonstrate why this is the case. Do you recall the previous example where we provided the following task:
+
+```
+The odd numbers in this group add up to an even number: 15, 32, 5, 13, 82, 7, 1. 
+
+A: 
+```
+
+If we try this again, the model outputs the following:
+
+```
+Yes, the odd numbers in this group add up to 107, which is an even number.
+```
+
+This is not the correct response, which not only highlights the limitations of these systems but that there is a need for more advanced prompt engineering. 
+
+Let's try to add some examples to see if few-shot prompting improves the results.
+
+*Prompt:*
+```
+The odd numbers in this group add up to an even number: 4, 8, 9, 15, 12, 2, 1.
+A: The answer is False.
+
+The odd numbers in this group add up to an even number: 17,  10, 19, 4, 8, 12, 24.
+A: The answer is True.
+
+The odd numbers in this group add up to an even number: 16,  11, 14, 4, 8, 13, 24.
+A: The answer is True.
+
+The odd numbers in this group add up to an even number: 17,  9, 10, 12, 13, 4, 2.
+A: The answer is False.
+
+The odd numbers in this group add up to an even number: 15, 32, 5, 13, 82, 7, 1. 
+A: 
+```
+
+*Output:*
+```
+The answer is True.
+```
+
+That didn't work. It seems like few-shot prompting is not enough to get reliable responses for this type of reasoning problem. The example above provides basic information on the task. If you take a closer look, the type of task we have introduced involves a few more reasoning steps. In other words, it might help if we break the problem down into steps and demonstrate that to the model. More recently, [chain-of-thought (CoT) prompting](https://arxiv.org/abs/2201.11903) has been popularized to address more complex arithmetic, commonsense, and symbolic reasoning tasks.
+
+Overall, it seems that providing examples is useful for solving some tasks. When zero-shot prompting and few-shot prompting are not sufficient, it might mean that whatever was learned by the model isn't enough to do well at the task. From here it is recommended to start thinking about fine-tuning your models or experimenting with more advanced prompting techniques. Up next we talk about one of the popular prompting techniques called chain-of-thought prompting which has gained a lot of popularity. 
+
+---
+
+## Chain-of-Thought Prompting
+
+Introduced in [Wei et al. (2022)](https://arxiv.org/abs/2201.11903), chain-of-thought (CoT) prompting enables complex reasoning capabilities through intermediate reasoning steps. You can combine it with few-shot prompting to get better results on more complex tasks that require reasoning before responding.
+
+*Prompt:*
+```
+The odd numbers in this group add up to an even number: 4, 8, 9, 15, 12, 2, 1.
+A: Adding all the odd numbers (9, 15, 1) gives 25. The answer is False.
+
+The odd numbers in this group add up to an even number: 17,  10, 19, 4, 8, 12, 24.
+A: Adding all the odd numbers (17, 19) gives 36. The answer is True.
+
+The odd numbers in this group add up to an even number: 16,  11, 14, 4, 8, 13, 24.
+A: Adding all the odd numbers (11, 13) gives 24. The answer is True.
+
+The odd numbers in this group add up to an even number: 17,  9, 10, 12, 13, 4, 2.
+A: Adding all the odd numbers (17, 9, 13) gives 39. The answer is False.
+
+The odd numbers in this group add up to an even number: 15, 32, 5, 13, 82, 7, 1. 
+A:
+```
+
+*Output:*
+```
+Adding all the odd numbers (15, 5, 13, 7, 1) gives 41. The answer is False.
+```
+
+Wow! We can see a perfect result when we provided the reasoning step. We can solve this task by providing even fewer examples, i.e., just one example seems enough:
+
+*Prompt:*
+```
+The odd numbers in this group add up to an even number: 4, 8, 9, 15, 12, 2, 1.
+A: Adding all the odd numbers (9, 15, 1) gives 25. The answer is False.
+
+The odd numbers in this group add up to an even number: 15, 32, 5, 13, 82, 7, 1. 
+A:
+```
+
+*Output:*
+```
+Adding all the odd numbers (15, 5, 13, 7, 1) gives 41. The answer is False.
+```
+
+Keep in mind that the authors claim that this is an emergent ability that arises with sufficiently large language models. 
+
+---
+
+## Zero-Shot CoT
+
+One recent idea that came out more recently is the idea of [zero-shot CoT](https://arxiv.org/abs/2205.11916) (Kojima et al. 2022) that essentially involves adding "Let's think step by step" to the original prompt. Let's try a simple problem and see how the model performs:
+
+*Prompt:*
+```
+I went to the market and bought 10 apples. I gave 2 apples to the neighbor and 2 to the repairman. I then went and bought 5 more apples and ate 1. How many apples did I remain with?
+```
+
+*Output:*
+```
+11 apples
+```
+
+The answer is incorrect! Now Let's try with the special prompt. 
+
+*Prompt:*
+```
+I went to the market and bought 10 apples. I gave 2 apples to the neighbor and 2 to the repairman. I then went and bought 5 more apples and ate 1. How many apples did I remain with?
+
+Let's think step by step.
+```
+
+*Output:*
+```
+First, you started with 10 apples.
+You gave away 2 apples to the neighbor and 2 to the repairman, so you had 6 apples left.
+Then you bought 5 more apples, so now you had 11 apples.
+Finally, you ate 1 apple, so you would remain with 10 apples.
+```
+
+It's impressive that this simple prompt is effective at this task. This is particularly useful where you don't have too many examples to use in the prompt.
+
+---
+
+## Self-Consistency
+
+Perhaps one of the more advanced techniques out there for prompt engineering is self-consistency. Proposed by [Wang et al. (2022)](https://arxiv.org/pdf/2203.11171.pdf), self-consistency aims "to replace the naive greedy decoding used in chain-of-thought prompting". The idea is to sample multiple, diverse reasoning paths through few-shot CoT, and use the generations to select the most consistent answer. This helps to boost the performance of CoT prompting on tasks involving arithmetic and commonsense reasoning.
+
+Let's try the following example for arithmetic reasoning:
+
+*Prompt:*
+```
+When I was 6 my sister was half my age. Now
+I’m 70 how old is my sister?
+```
+
+*Output:*
+```
+35
+```
+
+The output is wrong! How may we improve this with self-consistency? Let's try it out. We will use the few-shot exemplars from Wang et al. 2022 (Table 17):
+
+*Prompt:*
+```
+Q: There are 15 trees in the grove. Grove workers will plant trees in the grove today. After they are done,
+there will be 21 trees. How many trees did the grove workers plant today?
+A: We start with 15 trees. Later we have 21 trees. The difference must be the number of trees they planted.
+So, they must have planted 21 - 15 = 6 trees. The answer is 6.
+
+Q: If there are 3 cars in the parking lot and 2 more cars arrive, how many cars are in the parking lot?
+A: There are 3 cars in the parking lot already. 2 more arrive. Now there are 3 + 2 = 5 cars. The answer is 5.
+
+Q: Leah had 32 chocolates and her sister had 42. If they ate 35, how many pieces do they have left in total?
+A: Leah had 32 chocolates and Leah’s sister had 42. That means there were originally 32 + 42 = 74
+chocolates. 35 have been eaten. So in total they still have 74 - 35 = 39 chocolates. The answer is 39.
+
+Q: Jason had 20 lollipops. He gave Denny some lollipops. Now Jason has 12 lollipops. How many lollipops
+did Jason give to Denny?
+A: Jason had 20 lollipops. Since he only has 12 now, he must have given the rest to Denny. The number of
+lollipops he has given to Denny must have been 20 - 12 = 8 lollipops. The answer is 8.
+
+Q: Shawn has five toys. For Christmas, he got two toys each from his mom and dad. How many toys does
+he have now?
+A: He has 5 toys. He got 2 from mom, so after that he has 5 + 2 = 7 toys. Then he got 2 more from dad, so
+in total he has 7 + 2 = 9 toys. The answer is 9.
+
+Q: There were nine computers in the server room. Five more computers were installed each day, from
+monday to thursday. How many computers are now in the server room?
+A: There are 4 days from monday to thursday. 5 computers were added each day. That means in total 4 * 5 =
+20 computers were added. There were 9 computers in the beginning, so now there are 9 + 20 = 29 computers.
+The answer is 29.
+
+Q: Michael had 58 golf balls. On tuesday, he lost 23 golf balls. On wednesday, he lost 2 more. How many
+golf balls did he have at the end of wednesday?
+A: Michael initially had 58 balls. He lost 23 on Tuesday, so after that he has 58 - 23 = 35 balls. On
+Wednesday he lost 2 more so now he has 35 - 2 = 33 balls. The answer is 33.
+
+Q: Olivia has $23. She bought five bagels for $3 each. How much money does she have left?
+A: She bought 5 bagels for $3 each. This means she spent 5
+
+Q: When I was 6 my sister was half my age. Now I’m 70 how old is my sister?
+A:
+```
+
+*Output 1:*
+```
+When I was 6 my sister was half my age, so she was 3. Now I am 70, so she is 70 - 3 = 67. The answer is 67.
+```
+
+*Output 2:*
+```
+When the narrator was 6, his sister was half his age, which is 3. Now that the narrator is 70, his sister would be 70 - 3 = 67 years old. The answer is 67.
+```
+
+*Output 3:*
+```
+When I was 6 my sister was half my age, so she was 3. Now I am 70, so she is 70/2 = 35. The answer is 35.
+```
+
+Computing for the final answer involves a few steps (check out the paper for the details) but for the sake of simplicity, we can see that there is already a majority answer emerging so that would essentially become the final answer. 
+
+---
+## Generated Knowledge Prompting
+
+LLMs continue to be improved and one popular technique includes the ability to incorporate knowledge or information to help the model make more accurate predictions. 
+
+Using a similar idea, can the model also be used to generate knowledge before making a prediction? That's what is attempted in the paper by [Liu et al. 2022](https://arxiv.org/pdf/2110.08387.pdf) -- generate knowledge to be used as part of the prompt. In particular, how helpful is this for tasks such as commonsense reasoning?
+
+Let's try a simple prompt:
+
+*Prompt:*
+```
+Part of golf is trying to get a higher point total than others. Yes or No?
+```
+
+*Output:*
+```
+Yes.
+```
+
+This type of mistake reveals the limitations of LLMs to perform tasks that require more knowledge about the world. How do we improve this with knowledge generation?
+
+First, we generate a few "knowledges":
+
+*Prompt:*
+```
+Input: Greece is larger than mexico.
+Knowledge: Greece is approximately 131,957 sq km, while Mexico is approximately 1,964,375 sq km, making Mexico 1,389% larger than Greece.
+
+Input: Glasses always fog up.
+Knowledge: Condensation occurs on eyeglass lenses when water vapor from your sweat, breath, and ambient humidity lands on a cold surface, cools, and then changes into tiny drops of liquid, forming a film that you see as fog. Your lenses will be relatively cool compared to your breath, especially when the outside air is cold.
+
+Input: A fish is capable of thinking.
+Knowledge: Fish are more intelligent than they appear. In many areas, such as memory, their cognitive powers match or exceed those of ’higher’ vertebrates including non-human primates. Fish’s long-term memories help them keep track of complex social relationships.
+
+Input: A common effect of smoking lots of cigarettes in one’s lifetime is a higher than normal chance of getting lung cancer.
+Knowledge: Those who consistently averaged less than one cigarette per day over their lifetime had nine times the risk of dying from lung cancer than never smokers. Among people who smoked between one and 10 cigarettes per day, the risk of dying from lung cancer was nearly 12 times higher than that of never smokers.
+
+Input: A rock is the same size as a pebble.
+Knowledge: A pebble is a clast of rock with a particle size of 4 to 64 millimetres based on the Udden-Wentworth scale of sedimentology. Pebbles are generally considered larger than granules (2 to 4 millimetres diameter) and smaller than cobbles (64 to 256 millimetres diameter).
+
+Input: Part of golf is trying to get a higher point total than others.
+Knowledge:
+```
+
+*Knowledge 1:*
+```
+The objective of golf is to play a set of holes in the least number of strokes. A round of golf typically consists of 18 holes. Each hole is played once in the round on a standard golf course. Each stroke is counted as one point, and the total number of strokes is used to determine the winner of the game.
+```
+
+*Knowledge 2:*
+```
+Golf is a precision club-and-ball sport in which competing players (or golfers) use many types of clubs to hit balls into a series of holes on a course using the fewest number of strokes. The goal is to complete the course with the lowest score, which is calculated by adding up the total number of strokes taken on each hole. The player with the lowest score wins the game.
+```
+
+We are using the prompt provided in the paper by [Liu et al. 2022](https://arxiv.org/pdf/2110.08387.pdf).
+
+The next step is to integrate the knowledge and get a prediction. I reformatted the question into QA format to guide the answer format.
+
+*Prompt:*
+```
+Question: Part of golf is trying to get a higher point total than others. Yes or No?
+
+Knowledge: The objective of golf is to play a set of holes in the least number of strokes. A round of golf typically consists of 18 holes. Each hole is played once in the round on a standard golf course. Each stroke is counted as one point, and the total number of strokes is used to determine the winner of the game.
+
+Explain and Answer: 
+```
+
+*Answer 1 (confidence very high):*
+```
+No, the objective of golf is not to get a higher point total than others. Rather, the objective is to play a set of holes in the least number of strokes. The total number of strokes is used to determine the winner of the game, not the total number of points.
+```
+
+
+```
+Question: Part of golf is trying to get a higher point total than others. Yes or No?
+
+Knowledge: Golf is a precision club-and-ball sport in which competing players (or golfers) use many types of clubs to hit balls into a series of holes on a course using the fewest number of strokes. The goal is to complete the course with the lowest score, which is calculated by adding up the total number of strokes taken on each hole. The player with the lowest score wins the game.
+
+Explain and Answer:
+```
+
+*Answer 2 (confidence is a lot lower):*
+```
+Yes, part of golf is trying to get a higher point total than others. Each player tries to complete the course with the lowest score, which is calculated by adding up the total number of strokes taken on each hole. The player with the lowest score wins the game.
+```
+
+Some really interesting things happened with this example. In the first answer, the model was very confident but in the second not so much. I simplify the process for demonstration purposes but there are a few more details to consider when arriving at the final answer. Check out the paper for more.
+
+---
+
+## Automatic Prompt Engineer (APE)
+
+![](../img/APE.png)
+
+[Zhou et al., (2022)](https://arxiv.org/abs/2211.01910) propose automatic prompt engineer (APE) a framework for automatic instruction generation and selection. The instruction generation problem is framed as natural language synthesis addressed as a black-box optimization problem using LLMs to generate and search over candidate solutions. 
+
+The first step involves a large language model (as an inference model) that is given output demonstrations to generate instruction candidates for a task. These candidate solutions will guide the search procedure. The instructions are executed using a target model, and then the most appropriate instruction is selected based on computed evaluation scores. 
+
+APE discovers a better zero-shot CoT prompt than the human engineered "Let's think step by step" prompt (Kojima et al., 2022).
+
+The prompt "Let's work this out in a step by step way to be sure we have the right answer." elicits chain-of-though reasoning and improves performance on the MultiArith and GSM8K benchmarks:
+
+![](../img/ape-zero-shot-cot.png)
+
+This paper touches on an important topic related to prompt engineering which is the idea of automatically optimizing prompts. While we don't go deep into this topic in this guide, here are a few key papers if you are interested in the topic:
+
+- [AutoPrompt](https://arxiv.org/abs/2010.15980) - proposes an approach to automatically create prompts for a diverse set of tasks based on gradient-guided search.
+- [Prefix Tuning](https://arxiv.org/abs/2101.00190) - a lightweight alternative to fine-tuning that prepends a trainable continuous prefix for NLG tasks. 
+- [Prompt Tuning](https://arxiv.org/abs/2104.08691) - proposes a mechanism for learning soft prompts through backpropagation.
+
+---
+[Previous Section (Basic Prompting)](./prompts-basic-usage.md)
+
+[Next Section (Applications)](./prompts-applications.md)

--- a/resources/guides/dair-ai/prompts-intro.md
+++ b/resources/guides/dair-ai/prompts-intro.md
@@ -1,0 +1,267 @@
+# Prompting Introduction
+
+Prompt engineering is a relatively new discipline for developing and optimizing prompts to efficiently use language models (LMs) for a wide variety of applications and research topics. Prompt engineering skills help to better understand the capabilities and limitations of large language models (LLMs). Researchers use prompt engineering to improve the capacity of LLMs on a wide range of common and complex tasks such as question answering and arithmetic reasoning. Developers use prompt engineering to design robust and effective prompting techniques that interface with LLMs and other tools.
+
+This guide covers the basics of standard prompts to provide a rough idea of how to use prompts to interact and instruct large language models (LLMs). 
+
+All examples are tested with `text-davinci-003` (using OpenAI's playground) unless otherwise specified. It uses the default configurations, e.g., `temperature=0.7` and `top-p=1`.
+
+Topic:
+- [Basic Prompts](#basic-prompts)
+- [A Word on LLM Settings](#a-word-on-llm-settings)
+- [Standard Prompts](#standard-prompts)
+- [Prompt Elements](#elements-of-a-prompt)
+- [General Tips for Designing Prompts](#general-tips-for-designing-prompts)
+
+---
+
+## Basic Prompts
+
+You can already achieve a lot with prompts, but the quality of results depends on how much information you provide it. A prompt can contain information like the `instruction` or `question` you are passing to the model and include other details such as `inputs` or `examples`. 
+
+Here is a basic example of a simple prompt:
+
+*Prompt*
+```
+The sky is
+```
+
+*Output:*
+```
+blue
+
+The sky is blue on a clear day. On a cloudy day, the sky may be gray or white.
+```
+
+As you can see, the language model outputs a continuation of strings that make sense given the context `"The sky is"`. The output might be unexpected or far from the task we want to accomplish. 
+
+This basic example also highlights the necessity to provide more context or instructions on what specifically we want to achieve.
+
+Let's try to improve it a bit:
+
+*Prompt:*
+```
+Complete the sentence: 
+
+The sky is
+```
+
+*Output:*
+
+```
+ so  beautiful today.
+```
+
+Is that better? Well, we told the model to complete the sentence so the result looks a lot better as it follows exactly what we told it to do ("complete the sentence"). This approach of designing optimal prompts to instruct the model to perform a task is what's referred to as **prompt engineering**. 
+
+The example above is a basic illustration of what's possible with LLMs today. Today's LLMs can perform all kinds of advanced tasks that range from text summarization to mathematical reasoning to code generation.
+
+---
+## A Word on LLM Settings
+
+When working with prompts, you will be interacting with the LLM via an API or directly. You can configure a few parameters to get different results for your prompts. 
+
+**Temperature** - In short, the lower the temperature the more deterministic the results in the sense that the highest probable next token is always picked. Increasing the temperature could lead to more randomness encouraging more diverse or creative outputs. We are essentially increasing the weights of the other possible tokens. In terms of application, we might want to use a lower temperature for something like fact-based QA to encourage more factual and concise responses. For poem generation or other creative tasks, it might be beneficial to increase the temperature. 
+
+**Top_p** - Similarly, with top_p, a sampling technique with temperature called nucleus sampling, you can control how deterministic the model is at generating a response. If you are looking for exact and factual answers keep this low. If you are looking for more diverse responses, increase to a higher value. 
+
+The general recommendation is to alter one, not both.
+
+Before starting with some basic examples, keep in mind that your results may vary depending on the version of LLM you are using. 
+
+---
+## Standard Prompts
+
+We have tried a very simple prompt above. A standard prompt has the following format:
+
+```
+<Question>?
+```
+ 
+This can be formatted into a QA format, which is standard in a lot of QA dataset, as follows:
+
+```
+Q: <Question>?
+A: 
+```
+
+Given the standard format above, one popular and effective technique for prompting is referred to as few-shot prompting where we provide exemplars. Few-shot prompts can be formatted as follows:
+
+```
+<Question>?
+<Answer>
+
+<Question>?
+<Answer>
+
+<Question>?
+<Answer>
+
+<Question>?
+
+```
+
+
+And you can already guess that its QA format version would look like this:
+
+```
+Q: <Question>?
+A: <Answer>
+
+Q: <Question>?
+A: <Answer>
+
+Q: <Question>?
+A: <Answer>
+
+Q: <Question>?
+A:
+```
+
+Keep in mind that it's not required to use QA format. The format depends on the task at hand. For instance, you can perform a simple classification task and give exemplars that demonstrate the task as follows:
+
+*Prompt:*
+```
+This is awesome! // Positive
+This is bad! // Negative
+Wow that movie was rad! // Positive
+What a horrible show! //
+```
+
+*Output:*
+```
+Negative
+```
+
+Few-shot prompts enable in-context learning which is the ability of language models to learn tasks given only a few examples. We will see more of this in action in the upcoming guides.
+
+---
+## Elements of a Prompt
+
+As we cover more and more examples and applications that are possible with prompt engineering, you will notice that there are certain elements that make up a prompt. 
+
+A prompt can contain any of the following components:
+
+**Instruction** - a specific task or instruction you want the model to perform
+
+**Context** - can involve external information or additional context that can steer the model to better responses
+
+**Input Data** - is the input or question that we are interested to find a response for
+
+**Output Indicator** - indicates the type or format of the output.
+
+Not all the components are required for a prompt and the format depends on the task at hand. We will touch on more concrete examples in upcoming guides.
+
+---
+## General Tips for Designing Prompts
+
+Here are some tips to keep in mind while you are designing your prompts:
+
+
+### Start Simple
+As you get started with designing prompts, you should keep in mind that it is an iterative process that requires a lot of experimentation to get optimal results. Using a simple playground like OpenAI's or Cohere's is a good starting point. 
+
+You can start with simple prompts and keep adding more elements and context as you aim for better results. Versioning your prompt along the way is vital for this reason. As we read the guide you will see many examples where specificity, simplicity, and conciseness will often give you better results.
+
+When you have a big task that involves many different subtasks, you can try to break down the task into simpler subtasks and keep building up as you get better results. This avoids adding too much complexity to the prompt design process at the beginning.
+
+### The Instruction
+You can design effective prompts for various simple tasks by using commands to instruct the model what you want to achieve such as "Write", "Classify", "Summarize", "Translate", "Order", etc.
+
+Keep in mind that you also need to experiment a lot to see what works best. Try different instructions with different keywords, contexts, and data and see what works best for your particular use case and task. Usually, the more specific and relevant the context is to the task you are trying to perform, the better. We will touch on the importance of sampling and adding more context in the upcoming guides.
+
+Others recommend that instructions are placed at the beginning of the prompt. It's also recommended that some clear separator like "###" is used to separate the instruction and context. 
+
+For instance:
+
+*Prompt:*
+```
+### Instruction ###
+Translate the text below to Spanish:
+
+Text: "hello!"
+```
+
+*Output:*
+```
+¡Hola!
+```
+
+### Specificity
+Be very specific about the instruction and task you want the model to perform. The more descriptive and detailed the prompt is, the better the results. This is particularly important when you have a desired outcome or style of generation you are seeking. There aren't specific tokens or keywords that lead to better results. It's more important to have a good format and descriptive prompt. Providing examples in the prompt is very effective to get desired output in specific formats. 
+
+When designing prompts you should also keep in mind the length of the prompt as there are limitations regarding how long this can be. Thinking about how specific and detailed you should be is something to consider. Too many unnecessary details are not necessarily a good approach. The details should be relevant and contribute to the task at hand. This is something you will need to experiment with a lot. We encourage a lot of experimentation and iteration to optimize prompts for your applications.
+
+As an example, let's try a simple prompt to extract specific information from a piece of text.
+
+*Prompt:*
+```
+Extract the name of places in the following text. 
+
+Desired format:
+Place: <comma_separated_list_of_places>
+
+Input: "Although these developments are encouraging to researchers, much is still a mystery. “We often have a black box between the brain and the effect we see in the periphery,” says Henrique Veiga-Fernandes, a neuroimmunologist at the Champalimaud Centre for the Unknown in Lisbon. “If we want to use it in the therapeutic context, we need to understand the mechanism."
+```
+
+*Output:*
+```
+Place: Champalimaud Centre for the Unknown, Lisbon
+```
+
+The input text is obtained from [this Nature article](https://www.nature.com/articles/d41586-023-00509-z).
+
+### Avoid Impreciseness
+
+Given the tips above about being detailed and improving format, it's easy to fall into the trap of wanting to be too clever about prompts and potentially creating imprecise descriptions. It's often better to be specific and direct. The analogy here is very similar to effective communication -- the more direct, the more effective the message gets across.
+
+For example, you might be interested in learning the concept of prompt engineering. You might try something like:
+
+```
+Explain the concept of prompt engineering. Keep the explanation short, only a few sentences, and don't be too descriptive.
+```
+
+It's not clear from the prompt above how many sentences to use and what style. You might still somewhat get good responses with the above prompts but the better prompt would be one that is very specific, concise, and to the point. Something like:
+
+```
+Use 2-3 sentences to explain the concept of prompt engineering to a high school student.
+```
+
+### To do or not to do?
+Another common tip when designing prompts is to avoid saying what not to do but say what to do instead. This encourages more specificity and focuses on the details that lead to good responses from the model.
+
+Here is an example of a movie recommendation chatbot failing at exactly what I don't want it to do because of how I wrote the instruction -- focusing on what not to do. 
+
+*Prompt:*
+```
+The following is an agent that recommends movies to a customer. DO NOT ASK FOR INTERESTS. DO NOT ASK FOR PERSONAL INFORMATION.
+
+Customer: Please recommend a movie based on my interests.
+Agent: 
+```
+
+*Output:*
+```
+Sure, I can recommend a movie based on your interests. What kind of movie would you like to watch? Do you prefer action, comedy, romance, or something else?
+```
+
+Here is a better prompt:
+
+*Prompt:*
+```
+The following is an agent that recommends movies to a customer. The agent is responsible to recommend a movie from the top global trending movies. It should refrain from asking users for their preferences and avoid asking for personal information. If the agent doesn't have a movie to recommend, it should respond "Sorry, couldn't find a movie to recommend today.".
+
+Customer: Please recommend a movie based on my interests.
+Agent:
+```
+
+*Output:*
+```
+Sorry, I don't have any information about your interests. However, here's a list of the top global trending movies right now: [list of movies]. I hope you find something you like!
+```
+
+Some of the examples above were adopted from the ["Best practices for prompt engineering with OpenAI API" article.](https://help.openai.com/en/articles/6654000-best-practices-for-prompt-engineering-with-openai-api)
+
+
+---
+[Next Section (Basic Prompting)](./prompts-basic-usage.md)

--- a/resources/guides/openai-cookbook/LICENSE
+++ b/resources/guides/openai-cookbook/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 OpenAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/resources/guides/openai-cookbook/techniques-to-improve-reliability.md
+++ b/resources/guides/openai-cookbook/techniques-to-improve-reliability.md
@@ -1,0 +1,573 @@
+# Techniques to improve reliability
+
+When GPT-3 fails on a task, what should you do?
+
+- Search for a better prompt that elicits more reliable answers?
+- Invest in thousands of examples to fine-tune a custom model?
+- Assume the model is incapable of the task, and move on?
+
+There is no simple answer - it depends. However, if your task involves logical reasoning or complexity, consider trying the techniques in this article to build more reliable, high-performing prompts.
+
+## Why GPT-3 fails on complex tasks
+
+If you were asked to multiply 13 by 17, would the answer pop immediately into your mind? For most of us, probably not. Yet, that doesn't mean humans are incapable of two-digit multiplication. With a few seconds, and some pen and paper, it's not too taxing to work out that 13 x 17 = 130 + 70 + 21 = 221.
+
+Similarly, if you give GPT-3 a task that's too complex to do in the time it takes to calculate its next token, it may confabulate an incorrect guess. Yet, akin to humans, that doesn't necessarily mean the model is incapable of the task. With some time and space to reason things out, the model still may be able to answer reliably.
+
+As an example, if you ask `gpt-3.5-turbo-instruct` the following math problem about juggling balls, it answers incorrectly:
+
+```gpt-3.5-turbo-instruct
+Q: A juggler has 16 balls. Half of the balls are golf balls and half of the golf balls are blue. How many blue golf balls are there?
+A:
+```
+
+```gpt-3.5-turbo-instruct
+There are 8 blue golf balls.
+```
+
+Does this mean that GPT-3 cannot do simple math problems? No; in fact, it turns out that by prompting the model with `Let's think step by step`, the model solves the problem reliably:
+
+```gpt-3.5-turbo-instruct
+Q: A juggler has 16 balls. Half of the balls are golf balls and half of the golf balls are blue. How many blue golf balls are there?
+A: Let's think step by step.
+```
+
+```gpt-3.5-turbo-instruct
+There are 16 balls in total.
+Half of the balls are golf balls.
+That means that there are 8 golf balls.
+Half of the golf balls are blue.
+That means that there are 4 blue golf balls.
+```
+
+Of course, it's hard to tell from only a single example whether this `Let's think step by step` trick actually works in general or just got lucky on this particular problem. But it really does work. On a benchmark of word math problems, the `Let's think step by step` trick raised GPT-3's solve rate massively, from a worthless 18% to a decent 79%!
+
+## Model capabilities depend on context
+
+When learning to work with GPT-3, one common conceptual mistake is to believe that its capabilities are fixed across all contexts. E.g., if GPT-3 gets a simple logic question wrong, then it must be incapable of simple logic.
+
+But as the `Let's think step by step` example illustrates, apparent failures of GPT-3 can sometimes be remedied with a better prompt that helps the model steer itself toward the correct output.
+
+## How to improve reliability on complex tasks
+
+The rest of this article shares techniques for improving reliability of large language models on complex tasks. Although some of the techniques are specific to certain types of problems, many of them are built upon general principles that can be applied to a wide range of tasks, e.g.:
+
+- Give clearer instructions
+- Split complex tasks into simpler subtasks
+- Structure the instruction to keep the model on task
+- Prompt the model to explain before answering
+- Ask for justifications of many possible answers, and then synthesize
+- Generate many outputs, and then use the model to pick the best one
+- Fine-tune custom models to maximize performance
+
+## Split complex tasks into simpler tasks
+
+One way to give a model more time and space to think is to break tasks into simpler pieces.
+
+As an example, consider a task where we ask the model a multiple-choice question about some text - in this case, a game of Clue. When asked directly, `gpt-3.5-turbo-instruct` isn't able to put clues 3 & 5 together, and answers incorrectly:
+
+```gpt-3.5-turbo-instruct
+Use the following clues to answer the following multiple-choice question.
+
+Clues:
+1. Miss Scarlett was the only person in the lounge.
+2. The person with the pipe was in the kitchen.
+3. Colonel Mustard was the only person in the observatory.
+4. Professor Plum was not in the library nor the billiard room.
+5. The person with the candlestick was in the observatory.
+
+Question: Was Colonel Mustard in the observatory with the candlestick?
+(a) Yes; Colonel Mustard was in the observatory with the candlestick
+(b) No; Colonel Mustard was not in the observatory with the candlestick
+(c) Unknown; there is not enough information to determine whether Colonel Mustard was in the observatory with the candlestick
+
+Solution:
+```
+
+```gpt-3.5-turbo-instruct
+(c) Unknown; there is not enough information to determine whether Colonel Mustard was in the observatory with the candlestick
+```
+
+Although clues 3 and 5 establish that Colonel Mustard was the only person in the observatory and that the person in the observatory had the candlestick, the model fails to combine them into a correct answer of (a) Yes.
+
+However, instead of asking for the answer directly, we can split the task into three pieces:
+
+- First, go through the clues one by one and consider whether the clue is potentially relevant
+- Second, combine the relevant clues to reason out the answer to the question
+- Third, write the final answer: either (a), (b), or (c)
+
+```gpt-3.5-turbo-instruct
+Use the following clues to answer the following multiple-choice question, using the following procedure:
+(1) First, go through the clues one by one and consider whether the clue is potentially relevant
+(2) Second, combine the relevant clues to reason out the answer to the question
+(3) Third, map the answer to one of the multiple choice answers: either (a), (b), or (c)
+
+Clues:
+1. Miss Scarlett was the only person in the lounge.
+2. The person with the pipe was in the kitchen.
+3. Colonel Mustard was the only person in the observatory.
+4. Professor Plum was not in the library nor the billiard room.
+5. The person with the candlestick was in the observatory.
+
+Question: Was Colonel Mustard in the observatory with the candlestick?
+(a) Yes; Colonel Mustard was in the observatory with the candlestick
+(b) No; Colonel Mustard was not in the observatory with the candlestick
+(c) Unknown; there is not enough information to determine whether Colonel Mustard was in the observatory with the candlestick
+
+Solution:
+(1) First, go through the clues one by one and consider whether the clue is potentially relevant:
+```
+
+```gpt-3.5-turbo-instruct
+Clue 1: Miss Scarlett was the only person in the lounge. This clue is not relevant.
+Clue 2: The person with the pipe was in the kitchen. This clue is not relevant.
+Clue 3: Colonel Mustard was the only person in the observatory. This clue is relevant.
+Clue 4: Professor Plum was not in the library nor the billiard room. This clue is not relevant.
+Clue 5: The person with the candlestick was in the observatory. This clue is relevant.
+
+(2) Second, combine the relevant clues to reason out the answer to the question:
+Clue 3 and Clue 5 both say that the person with the candlestick was in the observatory. Colonel Mustard was the only person in the observatory, so Colonel Mustard was the person with the candlestick.
+
+(3) Third, write the final answer:
+(a) Yes; Colonel Mustard was in the observatory with the candlestick
+```
+
+By giving the model more time and space to think, and guiding it along a reasoning plan, it's able to figure out the correct answer of (a) Yes.
+
+Another benefit of splitting complex instructions into smaller subtasks is that it can help keep the model focused on each subtask.
+
+For example, if we ask `gpt-3.5-turbo-instruct` to summarize a text in its original language, the model can lapse back into English:
+
+```gpt-3.5-turbo-instruct
+Summarize the text using the original language of the text. The summary should be one sentence long.
+
+Text:
+"""
+La estadística (la forma femenina del término alemán Statistik, derivado a su vez del italiano statista, "hombre de Estado")​ es una ciencia que estudia la variabilidad, colección, organización, análisis, interpretación, y presentación de los datos, así como el proceso aleatorio que los genera siguiendo las leyes de la probabilidad.​ La estadística es una ciencia formal deductiva, con un conocimiento propio, dinámico y en continuo desarrollo obtenido a través del método científico formal. En ocasiones, las ciencias fácticas necesitan utilizar técnicas estadísticas durante su proceso de investigación factual, con el fin de obtener nuevos conocimientos basados en la experimentación y en la observación. En estos casos, la aplicación de la estadística permite el análisis de datos provenientes de una muestra representativa, que busca explicar las correlaciones y dependencias de un fenómeno físico o natural, de ocurrencia en forma aleatoria o condicional.
+"""
+
+Summary:
+```
+
+```gpt-3.5-turbo-instruct
+The text explains that statistics is a science that studies the variability, collection, organization, analysis, interpretation, and presentation of data, as well as the random process that generates them following the laws of probability.
+```
+
+However, if we first ask the model to identify the language of the text, and then summarize the text, it becomes more reliable:
+
+```gpt-3.5-turbo-instruct
+First, identify the language of the text. Second, summarize the text using the original language of the text. The summary should be one sentence long.
+
+Text:
+"""
+La estadística (la forma femenina del término alemán Statistik, derivado a su vez del italiano statista, "hombre de Estado")​ es una ciencia que estudia la variabilidad, colección, organización, análisis, interpretación, y presentación de los datos, así como el proceso aleatorio que los genera siguiendo las leyes de la probabilidad.​ La estadística es una ciencia formal deductiva, con un conocimiento propio, dinámico y en continuo desarrollo obtenido a través del método científico formal. En ocasiones, las ciencias fácticas necesitan utilizar técnicas estadísticas durante su proceso de investigación factual, con el fin de obtener nuevos conocimientos basados en la experimentación y en la observación. En estos casos, la aplicación de la estadística permite el análisis de datos provenientes de una muestra representativa, que busca explicar las correlaciones y dependencias de un fenómeno físico o natural, de ocurrencia en forma aleatoria o condicional.
+"""
+
+Language:
+```
+
+```gpt-3.5-turbo-instruct
+Spanish
+
+La estadística es una ciencia que estudia la variabilidad, colección, organización, análisis, interpretación, y presentación de los datos, así como el proceso aleatorio que los genera siguiendo las leyes de la probabilidad.
+```
+
+## Prompt the model to explain before answering
+
+Another powerful technique for improving the reliability of answers is to prompt the model to gradually reason out the answer rather than jumping immediately to the final answer. By 'thinking aloud' the model can be far more likely to arrive at the correct answer.
+
+### Zero-shot
+
+#### Method
+
+Published by [Takeshi Kojima et al. in 2022](https://arxiv.org/abs/2205.11916), the easiest way to prompt a model to reason out the answer is to simply prepend answers with `Let's think step by step.` Figure 2 illustrates an example:
+
+[![zero-shot reasoning example](/images/zero-shot_reasoners_fig2.png)
+<br>Source: _Large Language Models are Zero-Shot Reasoners_ by Takeshi Kojima et al. (2022).](https://arxiv.org/abs/2205.11916)
+
+#### Results
+
+Applying this simple trick to the MultiArith math dataset, the authors found `Let's think step by step` quadrupled the accuracy, from 18% to 79%!
+
+[![zero-shot reasoning example](/images/zero-shot_reasoners_tab5.png)
+<br>Source: _Large Language Models are Zero-Shot Reasoners_ by Takeshi Kojima et al. (2022).](https://arxiv.org/abs/2205.11916)
+
+#### Implications
+
+Although the `Let's think step by step` trick works well on math problems, it's not effective on all tasks. The authors found that it was most helpful for multi-step arithmetic problems, symbolic reasoning problems, strategy problems, and other reasoning problems. It didn't help with simple math problems or common sense questions, and presumably wouldn't help with many other non-reasoning tasks either.
+
+[![zero-shot reasoning example](/images/zero-shot_reasoners_tab1.png)
+<br>Source: _Large Language Models are Zero-Shot Reasoners_ by Takeshi Kojima et al. (2022).](https://arxiv.org/abs/2205.11916)
+
+To learn more, read the [full paper](https://arxiv.org/abs/2205.11916).
+
+If you apply this technique to your own tasks, don't be afraid to experiment with customizing the instruction. `Let's think step by step` is rather generic, so you may find better performance with instructions that hew to a stricter format customized to your use case. For example, you can try more structured variants like `First, think step by step about why X might be true. Second, think step by step about why Y might be true. Third, think step by step about whether X or Y makes more sense.`. And you can even give the model an example format to help keep it on track, e.g.:
+
+```gpt-3.5-turbo-instruct
+Using the IRS guidance below, answer the following questions using this format:
+(1) For each criterion, determine whether it is met by the vehicle purchase
+- {Criterion} Let's think step by step. {explanation} {yes or no, or if the question does not apply then N/A}.
+(2) After considering each criterion in turn, phrase the final answer as "Because of {reasons}, the answer is likely {yes or no}."
+
+IRS guidance:
+"""
+You may be eligible for a federal tax credit under Section 30D if you purchased a car or truck that meets the following criteria:
+- Does the vehicle have at least four wheels?
+- Does the vehicle weigh less than 14,000 pounds?
+- Does the vehicle draw energy from a battery with at least 4 kilowatt hours that may be recharged from an external source?
+- Was the vehicle purchased in a year before 2022?
+  - If so, has the manufacturer sold less than 200,000 qualifying vehicles? (Tesla and GM have sold more than 200,000 qualifying vehicles.)
+- Was the vehicle purchased in a year after 2022?
+  - If so, is the vehicle present in the following list of North American-assembled vehicles? (The only electric vehicles assembled in North America are the Audi Q5, BMW 330e, BMW X5, Chevrolet Bolt EUV, Chevrolet Bolt EV, Chrysler Pacifica PHEV, Ford Escape PHEV, Ford F Series, Ford Mustang MACH E, Ford Transit Van, GMC Hummer Pickup, GMC Hummer SUV, Jeep Grand Cherokee PHEV, Jeep Wrangler PHEV, Lincoln Aviator PHEV, Lincoln Corsair Plug-in, Lucid Air, Nissan Leaf, Rivian EDV, Rivian R1S, Rivian R1T, Tesla Model 3, Tesla Model S, Tesla Model X, Tesla Model Y, Volvo S60, BMW 330e, Bolt EV, Cadillac Lyriq, Mercedes EQS SUV, and Nissan Leaf.)
+"""
+
+Question: Can I claim a federal tax credit for my Toyota Prius Prime bought in 2021?
+
+Solution:
+
+(1) For each criterion, determine whether it is met by the vehicle purchase
+- Does the vehicle have at least four wheels? Let's think step by step.
+```
+
+```gpt-3.5-turbo-instruct
+ The Toyota Prius Prime has four wheels, so the answer is yes.
+- Does the vehicle weigh less than 14,000 pounds? Let's think step by step. The Toyota Prius Prime weighs less than 14,000 pounds, so the answer is yes.
+- Does the vehicle draw energy from a battery with at least 4 kilowatt hours that may be recharged from an external source? Let's think step by step. The Toyota Prius Prime has a battery with at least 4 kilowatt hours that may be recharged from an external source, so the answer is yes.
+- Was the vehicle purchased in a year before 2022? Let's think step by step. The Toyota Prius Prime was purchased in 2021, which is before 2022, so the answer is yes.
+- Was the vehicle purchased in a year after 2022? N/A
+- If so, is the vehicle present in the following list of North American-assembled vehicles? N/A
+
+(2) After considering each criterion in turn, phrase the final answer as "Because of {reasons}, the answer is likely {yes or no}."
+
+Because the Toyota Prius Prime meets all of the criteria for a federal tax credit, the answer is likely yes.
+```
+
+### Few-shot examples
+
+#### Method
+
+Prompting the model to reason out its answers can be done in many ways. One way is to demonstrate with a few examples ('few-shot'), as studied by [Jason Wei and Denny Zhou et al. from Google](https://ai.googleblog.com/2022/05/language-models-perform-reasoning-via.html). Here's an example few-shot chain-of-thought prompt:
+
+[![chain of thought example](/images/chain_of_thought_fig1.png)
+<br>Source: _Chain of Thought Prompting Elicits Reasoning in Large Language Models_ Jason Wei and Denny Zhou et al. (2022)](https://ai.googleblog.com/2022/05/language-models-perform-reasoning-via.html)
+
+More demonstrations of reasoning chains written by human labelers:
+
+[![chain of thought example](/images/chain_of_thought_fig3.png)
+<br>Source: _Chain of Thought Prompting Elicits Reasoning in Large Language Models_ Jason Wei and Denny Zhou et al. (2022)](https://ai.googleblog.com/2022/05/language-models-perform-reasoning-via.html)
+
+[(Note that it has been called into question whether pears actually float)](https://twitter.com/Meaningness/status/1561062170074370048?s=20&t=mpHt8f3RRboztXxdhLFnWQ)
+
+#### Results
+
+Testing on grade school math problems, the authors found that chain of thought prompting tripled the solve rate, from 18% to 57%.
+
+[![chain of thought example](/images/chain_of_thought_fig5.png)
+<br>Source: _Chain of Thought Prompting Elicits Reasoning in Large Language Models_ Jason Wei and Denny Zhou et al. (2022)](https://ai.googleblog.com/2022/05/language-models-perform-reasoning-via.html)
+
+In addition to math problems, chain of thought prompting also lifted performance on questions related to sports understanding, coin flip tracking, and last letter concatenation. In most cases, not many examples were need to saturate the performance gains (less than 8 or so).
+
+[![chain of thought example](/images/chain_of_thought_fig11.png)
+<br>Source: _Chain of Thought Prompting Elicits Reasoning in Large Language Models_ Jason Wei and Denny Zhou et al. (2022)](https://ai.googleblog.com/2022/05/language-models-perform-reasoning-via.html)
+
+To learn more, read the [full paper](https://arxiv.org/abs/2201.11903).
+
+#### Implications
+
+One advantage of the few-shot example-based approach relative to the `Let's think step by step` technique is that you can more easily specify the format, length, and style of reasoning that you want the model to perform before landing on its final answer. This can be particularly helpful in cases where the model isn't initially reasoning in the right way or depth.
+
+### Fine-tuned
+
+#### Method
+
+In general, to eke out maximum performance on a task, you'll need to fine-tune a custom model. However, fine-tuning a model using explanations may take thousands of example explanations, which are costly to write.
+
+In 2022, Eric Zelikman and Yuhuai Wu et al. published a clever procedure for using a few-shot prompt to generate a dataset of explanations that could be used to fine-tune a model. The idea is to use a few-shot prompt to generate candidate explanations, and only keep the explanations that produce the correct answer. Then, to get additional explanations for some of the incorrect answers, retry the few-shot prompt but with correct answers given as part of the question. The authors called their procedure STaR (Self-taught Reasoner):
+
+[![STaR procedure](/images/star_fig1.png)
+<br>Source: _STaR: Bootstrapping Reasoning With Reasoning_ by Eric Zelikman and Yujuai Wu et al. (2022)](https://arxiv.org/abs/2203.14465)
+
+With this technique, you can combine the benefits of fine-tuning with the benefits of chain-of-thought prompting without needing to write thousands of example explanations.
+
+#### Results
+
+When the authors applied this technique to a Common Sense Q&A dataset, they found that STaR outperformed both chain-of-thought prompting alone (73% > 37%) and fine-tuning alone (73% > 60%):
+
+[![STaR results](/images/star_tab1.png)
+<br>Source: _STaR: Bootstrapping Reasoning With Reasoning_ by Eric Zelikman and Yujuai Wu et al. (2022)](https://arxiv.org/abs/2203.14465)
+
+To learn more, read the [full paper](https://arxiv.org/abs/2203.14465).
+
+#### Implications
+
+Using a few-shot prompt to extend or modify a fine-tuning dataset is an idea that can be generalized beyond explanation writing. For example, if you have large quantities of unstructured text that you want to train on, you may find opportunities to use a prompt to extract a structured dataset from your unstructured text, and then fine-tune a custom model on that structured dataset.
+
+## Extensions to chain-of-thought prompting
+
+A number of extensions of chain-of-thought prompting have been published as well.
+
+### Selection-inference prompting
+
+#### Method
+
+Published by Antonia Creswell et al., one extension of the chain-of-thought technique is to split the single prompt for generating explanations and answers into smaller parts. First, a prompt selects a relevant subset of facts from the text ('selection prompt'). Then, a second prompt infers a conclusion from the selected facts ('inference prompt'). These prompts are then alternated in a loop to generate multiple steps of reasoning and eventually land on a final answer. The authors illustrate the idea in the following figure:
+
+[![Selection-inference prompting](/images/selection-inference_fig1.png)
+<br>Source: _Selection-Inference: Exploiting Large Language Models for Interpretable Logical Reasoning_ by Antonia Creswell et al. (2022)](https://arxiv.org/abs/2205.09712)
+
+#### Results
+
+When applied to a 7B-parameter model, the authors found that selection-inference prompting substantially improved performance relative to chain-of-thought prompting on the bAbi and Proof Writer benchmark tasks (both of which require longer sequences of reasoning steps). The best performance they achieved combined both selection-inference prompting with fine-tuning.
+
+[![Selection-inference prompting](/images/selection-inference_fig4.png)
+<br>Source: _Selection-Inference: Exploiting Large Language Models for Interpretable Logical Reasoning_ by Antonia Creswell et al. (2022)](https://arxiv.org/abs/2205.09712)
+
+#### Implications
+
+Although the gains on these benchmarks were large, these benchmarks were specifically chosen because they required longer sequences of reasoning. On problems that don't require reasoning with many steps, the gains are likely smaller.
+
+The results highlight a couple of general lessons for working with large language models. One, splitting up complex tasks into smaller tasks is a great way to improve reliability and performance; the more atomic the task, the less room there is for the model to err. Two, getting maximum performance often means combining fine-tuning with whatever approach you've chosen.
+
+To learn more, read the [full paper](https://arxiv.org/abs/2205.09712).
+
+### Faithful reasoning architecture
+
+A few months after publishing the selection-inference prompting technique, the authors extended the technique in a follow-up paper, with ideas for:
+
+- figuring out when the selection-inference cycle should stop or continue
+- adding a value function to help search over multiple reasoning paths
+- reducing hallucination of fake facts by fine-tuning a model to reason about sentence labels (e.g., sen1) rather than writing out the sentences themselves
+
+#### Method
+
+In the original selection-inference technique, specialized 'selection' and 'inference' prompts are alternated to select facts and make inferences from those facts, combining to generate a sequence of reasoning steps.
+
+The authors extend this technique with two additional components.
+
+First, the authors add a 'halter' model that, after each inference step, is asked whether the inferences thus far are sufficient to answer the question. If yes, then the model generates a final answer.
+
+The halter models brings a couple of advantages:
+
+- it can tell the selection-inference process to stop or keep going, as necessary.
+- if the process never halts, you'll get no answer, which is often preferable to a hallucinated guess
+
+[![Faithful reasoning](/images/faithful-reasoning_fig3.png)
+<br>Source: _Faithful Reasoning Using Large Language Models_ by Antonia Creswell et al. (2022)](https://arxiv.org/abs/2208.14271)
+
+[![Faithful reasoning](/images/faithful-reasoning_fig5.png)
+<br>Source: _Faithful Reasoning Using Large Language Models_ by Antonia Creswell et al. (2022)](https://arxiv.org/abs/2208.14271)
+
+Second, the authors add a value function, which is used to assess the quality of reasoning steps and search over multiple reasoning trajectories. This echoes a common theme for increasing reliability; instead of generating a single answer from the model, generate a set of answers and then use some type of value function / discriminator / verifier model to pick the best one.
+
+[![Faithful reasoning](/images/faithful-reasoning_fig7.png)
+<br>Source: _Faithful Reasoning Using Large Language Models_ by Antonia Creswell et al. (2022)](https://arxiv.org/abs/2208.14271)
+
+In addition to these two extensions, the authors also use a trick to reduce hallucination of fake facts. Rather than asking the model to write out factual sentences, they fine-tune a model to work with sentence labels (e.g., sen1) instead. This helps prevent the model from hallucinating fake facts not mentioned in the prompt context.
+
+[![Faithful reasoning](/images/faithful-reasoning_fig4.png)
+<br>Source: _Faithful Reasoning Using Large Language Models_ by Antonia Creswell et al. (2022)](https://arxiv.org/abs/2208.14271)
+
+#### Results
+
+The authors evaluated their technique on two benchmarks: the ProofWriter task (not shown) and [EntailmentBankQA](https://allenai.org/data/entailmentbank) (shown). The technique increased accuracy substantially, especially on harder reasoning problems.
+
+![Faithful reasoning](/images/faithful-reasoning_tab2.png)
+<br>Source: _Faithful Reasoning Using Large Language Models_ by Antonia Creswell et al. (2022)](https://arxiv.org/abs/2208.14271)
+
+In addition, their sentence label manipulation trick essentially eliminated hallucination!
+
+![Faithful reasoning](/images/faithful-reasoning_tab5.png)
+<br>Source: _Faithful Reasoning Using Large Language Models_ by Antonia Creswell et al. (2022)](https://arxiv.org/abs/2208.14271)
+
+#### Implications
+
+This paper illustrates a number of helpful lessons for improving the reliability of large language models:
+
+- Split complex tasks into smaller, more reliable subtasks
+- Generate your answer in a step-by-step fashion, evaluating it along the way
+- Generate many possible answers and use another model or function to pick the ones that look best
+- Reduce hallucination by constraining what the model can say (e.g., by using sentence labels instead of sentences)
+- Maximize performance of models by fine-tuning them on specialized tasks
+
+To learn more, read the [full paper](https://arxiv.org/abs/2205.09712).
+
+### Least-to-most prompting
+
+In addition to doing poorly on long reasoning chains (where selection-inference shines), chain-of-thought prompting can especially struggle when the examples are short but the task is long.
+
+#### Method
+
+Least-to-most prompting is another technique that splits up reasoning tasks into smaller, more reliable subtasks. The idea is to elicit a subtask from the model by prompting it with something like `To solve {question}, we need to first solve: "`. Then, with that subtask in hand, the model can generate a solution. The solution is appended to the original question and the process is repeated until a final answer is produced.
+
+[![Least-to-most prompting](/images/least-to-most_fig1.png)
+<br>Source: _Least-to-most Prompting Enables Complex Reasoning in Large Language Models_ by Denny Zhou et al. (2022)](https://arxiv.org/abs/2205.10625)
+
+#### Results
+
+When applied to benchmarks involving long reasoning chains using `code-davinci-002` (which is optimized for code but can still understand text), the authors measured gains as large as 16% -> 99.7%!
+
+[
+![Least-to-most prompting results on last-letter-concatenation task](/images/least-to-most_tab4.png)
+![Least-to-most prompting results on SCAN](/images/least-to-most_tab9.png)
+![Least-to-most prompting results on DROP numerical reasoning](/images/least-to-most_tab11.png)
+<br>Source: _Least-to-most Prompting Enables Complex Reasoning in Large Language Models_ by Denny Zhou et al. (2022)](https://arxiv.org/abs/2205.10625)
+
+#### Implications
+
+Although the above gains from least-to-most prompting are impressive, they are measured on a very narrow set of tasks that require long reasoning chains.
+
+Still, they illustrate a common theme: increase reliability by (a) breaking complex tasks into smaller subtasks and (b) giving the model more time and space to work out the answer.
+
+To learn more, read the [full paper](https://arxiv.org/abs/2205.10625).
+
+## Related ideas
+
+### Maieutic prompting
+
+#### Method
+
+In contrast to the previous techniques, which try to maximize the likelihood of correct answers, another approach is to use GPT-3 to generate a tree of possible explanations (both correct _and incorrect_), and then analyze their relationships to guess at which set is correct. This technique was coined maieutic prompting by [Jaehun Jung et al. in May 2022](https://arxiv.org/abs/2205.11822) (maieutic means relating to the Socratic method of asking questions to elicit ideas).
+
+The method is complicated, and works as follows:
+
+- First, build a maieutic tree, where each node is a statement that could be true or false:
+  - Start with a multiple-choice question or true/false statement (e.g. `War cannot have a tie`)
+  - For each possible answer to the question, use the model to generate a corresponding explanation (with a prompt like `War cannot have a tie? True, because`)
+  - Then, prompt the model with the question and the generated explanation, and ask it to produce the answer. If reversing the explanation (with a prefix like `It is wrong to say that {explanation}`) reverses the answer, then the explanation is considered 'logically integral.'
+  - If an explanation is not logically integral, then repeat the above process recursively, with each explanation turned into a True or False question, and generate more explanations for each new question.
+  - After all of the recursive explaining is done, you end up with a tree of explanations, where each leaf on the tree has the property that reversing the explanation reverses the model's answer.
+- Second, convert the tree into a graph of relations:
+  - For each node in the tree, calculate the model's relative belief in each node (inferred from the probability of getting an answer of `True` to given an explanation)
+  - For each pair of nodes in the tree, use the model to identify whether they are entailed (implied) or contradicted
+- Third, find the most consistent set of beliefs and take those to be true:
+  - Specifically, using the strength of belief in each node and the logical relationships between them, formulate the problem as a weighted maximum satisfiability problem (MAX-SAT)
+  - Use a solver to the find the most self-consistent set of beliefs, and take those as true
+
+[
+![Maieutic prompting](/images/maieutic_fig2.png)
+![Maieutic prompting](/images/maieutic_fig6.png)
+<br>Source: _Maieutic Prompting: Logically Consistent Reasoning with Recursive Explanations_ by Jaehun Jung et al. (2022)](https://arxiv.org/abs/2205.11822)
+
+#### Results
+
+[![Maieutic prompting results](/images/maieutic_tab1.png)
+<br>Source: _Maieutic Prompting: Logically Consistent Reasoning with Recursive Explanations_ by Jaehun Jung et al. (2022)](https://arxiv.org/abs/2205.11822)
+
+#### Implications
+
+Beyond the complexity, one limitation of this method is that it appears to only apply to questions that can be posed as multiple-choice.
+
+To learn more, read the [full paper](https://arxiv.org/abs/2205.11822).
+
+## Extensions
+
+### Self-consistency
+
+#### Method
+
+For tasks with a discrete set of answers, one simple way to improve reliability is to sample multiple explanations & answers from the model (using a positive temperature) and then pick the final answer that appears most often.
+
+[![Self-consistency method](/images/self-consistency_fig1.png)
+<br>Source: _Self-Consistency Improves Chain of Thought Reasoning in Language Models_ by Xuezhi Wang et al. (2022)](https://arxiv.org/abs/2203.11171)
+
+#### Results
+
+This technique lifted accuracies by anywhere from 1 to 24 percentage points on a suite of math and reasoning benchmarks. (Plotted below are results from Google's LaMDA model; using Google's larger PaLM model, the baselines were higher but the gains were a bit smaller.)
+
+[![Self-consistency results](/images/self-consistency_fig3.png)
+<br>Source: _Self-Consistency Improves Chain of Thought Reasoning in Language Models_ by Xuezhi Wang et al. (2022)](https://arxiv.org/abs/2203.11171)
+
+#### Implications
+
+Although this technique is simple to implement, it can be costly. Generating a set of 10 answers will increase your costs by 10x.
+
+Also, as with many of these techniques, it applies only to tasks with a limited set of answers. For open-ended tasks where each answer is unique (such as writing a poem), it's not obvious what it would mean to pick the most common answer.
+
+Lastly, this technique ought to be most beneficial when there are multiple paths or phrasings to reach an answer; if there's only one path, then the technique may not help at all. An extreme example: If the task was to generate a single token answer, then taking the most common token from 100 generations would be no different than taking the token with the highest logprobs (which you can get with a single generation at temperature=0).
+
+### Verifiers
+
+Another key technique for improving task performance is to train a verifier or discriminator model to evaluate the outputs of the main generative model. If the discriminator rejects the output, then you can resample the generative model until you get an acceptable output. In many cases, it's easier to judge an answer than it is to create an answer, which helps explain the power of this method.
+
+#### Method
+
+In 2021, OpenAI researchers applied this technique to grade school math problems, using the following procedure:
+
+- First, they fine-tuned a model on questions and solutions
+- For each problem in the training set, they generated 100 solutions
+- Each of those 100 solutions was automatically labeled as either correct or incorrect, based on whether the final answer was correct
+- Using those solutions, with some labeled correct and some labeled incorrect, they fine-tuned a verifier model to classify whether a question and candidate solution was correct or incorrect
+- Finally, at test time, the generative model creates 100 solutions to each problem, and the one with the highest score according to the verifier model is picked as the final answer
+
+[![Verifier method](/images/verifiers_fig3.png)
+<br>Source: _Training Verifiers to Solve Math Word Problems_ by Karl Cobbe et al. (2021)](https://arxiv.org/abs/2110.14168)
+
+#### Results
+
+With a 175B GPT-3 model and 8,000 training examples, this technique substantially lifted grade school math accuracy from ~33% to ~55%.
+
+[![Verifier results](/images/verifiers_fig5.png)
+<br>Source: _Training Verifiers to Solve Math Word Problems_ by Karl Cobbe et al. (2021)](https://arxiv.org/abs/2110.14168)
+
+#### Implications
+
+Similar to the self-consistency technique, this method can get expensive, as generating, say, 100 solutions per task will increase your costs by roughly ~100x.
+
+## Theories of reliability
+
+Although the techniques above vary in their approach, they all share the goal of improving reliability on complex tasks. Mainly they do this by:
+
+- decomposing unreliable operations into smaller, more reliable operations (e.g., selection-inference prompting)
+- using multiple steps or multiple relationships to make the system's reliability greater than any individual component (e.g., maieutic prompting)
+
+### Probabilistic graphical models
+
+This paradigm of trying to build a reliable system out of less reliable components is reminiscent of probabilistic programming, and many of the analysis techniques of that field can be applied to this one.
+
+In the paper _Language Model Cascades_, David Dohan et al. interpret the above techniques in the paradigm of probabilistic graphical models:
+
+#### Chain of thought prompting
+
+[![graphical model of chain of thought prompting](/images/lm_cascades_fig1.png)
+<br>Source: _Language Model Cascades_ by David Dohan et al. (2022)](https://arxiv.org/abs/2207.10342)
+
+#### Fine-tuned chain of thought prompting / Self-taught reasoner
+
+[![graphical model of fine-tuned chain of thought prompting](/images/lm_cascades_fig3.png)
+<br>Source: _Language Model Cascades_ by David Dohan et al. (2022)](https://arxiv.org/abs/2207.10342)
+
+#### Selection-inference prompting
+
+[![graphical model of selection-inference prompting](/images/lm_cascades_fig4.png)
+<br>Source: _Language Model Cascades_ by David Dohan et al. (2022)](https://arxiv.org/abs/2207.10342)
+
+#### Verifiers
+
+[![graphical model of verifiers](/images/lm_cascades_fig5.png)
+<br>Source: _Language Model Cascades_ by David Dohan et al. (2022)](https://arxiv.org/abs/2207.10342)
+
+#### Implications
+
+Although formulating these techniques as probabilistic graphical models may not be immediately useful for solving any particular problem, the framework may be helpful in selecting, combining, and discovering new techniques.
+
+## Closing thoughts
+
+Research into large language models is very active and evolving rapidly. Not only do researchers continue to improve the models, they also continue to improve our understanding of how to best employ the models. To underscore the pace of these developments, note that all of the papers shared above were published within the past 12 months (as I write in Sep 2022).
+
+In the future, expect better models and better techniques to be published. Even if the specific techniques here are eclipsed by future best practices, the general principles behind them will likely remain a key part of any expert user's toolkit.
+
+## Bibliography
+
+| Lesson                                                                                                                         | Paper                                                                                                                                     | Date     |
+| ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Break complex tasks into simpler subtasks (and consider exposing the intermediate outputs to users)                            | [AI Chains: Transparent and Controllable Human-AI Interaction by Chaining Large Language Model Prompts](https://arxiv.org/abs/2110.01691) | 2021 Oct |
+| You can improve output by generating many candidates, and then picking the one that looks best                                 | [Training Verifiers to Solve Math Word Problems](https://arxiv.org/abs/2110.14168)                                                        | 2021 Oct |
+| On reasoning tasks, models do better when they reason step-by-step before answering                                            | [Chain of Thought Prompting Elicits Reasoning in Large Language Models](https://arxiv.org/abs/2201.11903)                                 | 2022 Jan |
+| You can improve step-by-step reasoning by generating many explanation-answer outputs, and picking the most popular answer      | [Self-Consistency Improves Chain of Thought Reasoning in Language Models](https://arxiv.org/abs/2203.11171)                               | 2022 Mar |
+| If you want to fine-tune a step-by-step reasoner, you can do it with multiple-choice question & answer data alone              | [STaR: Bootstrapping Reasoning With Reasoning](https://arxiv.org/abs/2203.14465)                                                          | 2022 Mar |
+| The step-by-step reasoning method works great even with zero examples                                                          | [Large Language Models are Zero-Shot Reasoners](https://arxiv.org/abs/2205.11916)                                                         | 2022 May |
+| You can do better than step-by-step reasoning by alternating a ‘selection’ prompt and an ‘inference’ prompt                    | [Selection-Inference: Exploiting Large Language Models for Interpretable Logical Reasoning](https://arxiv.org/abs/2205.09712)             | 2022 May |
+| On long reasoning problems, you can improve step-by-step reasoning by splitting the problem into pieces to solve incrementally | [Least-to-most Prompting Enables Complex Reasoning in Large Language Models](https://arxiv.org/abs/2205.10625)                            | 2022 May |
+| You can have the model analyze both good and bogus explanations to figure out which set of explanations are most consistent    | [Maieutic Prompting: Logically Consistent Reasoning with Recursive Explanations](https://arxiv.org/abs/2205.11822)                        | 2022 May |
+| You can think about these techniques in terms of probabilistic programming, where systems comprise unreliable components       | [Language Model Cascades](https://arxiv.org/abs/2207.10342)                                                                               | 2022 Jul |
+| You can eliminate hallucination with sentence label manipulation, and you can reduce wrong answers with a 'halter' prompt      | [Faithful Reasoning Using Large Language Models](https://arxiv.org/abs/2208.14271)                                                        | 2022 Aug |

--- a/segments/segment-1-core-prompting/README.md
+++ b/segments/segment-1-core-prompting/README.md
@@ -1,0 +1,9 @@
+# Segment 1: Core Prompting Skills for Reliable AI Results
+
+This module introduces the essential prompting techniques that work across industries, from IT and marketing to healthcare and law.
+
+## Topics
+- Essential prompt-writing techniques proven across domains
+- Common prompt pitfalls and how to avoid them
+- Evergreen, reusable prompt recipes to improve AI responses immediately
+- Interactive Q&A

--- a/segments/segment-2-multimodal-prompting/README.md
+++ b/segments/segment-2-multimodal-prompting/README.md
@@ -1,0 +1,10 @@
+# Segment 2: Multimodal Prompting—Beyond Text
+
+Explore how to prompt AI systems that process images and other media to create visuals and enhance presentations.
+
+## Topics
+- Writing effective prompts for ChatGPT Vision, Sora, and Midjourney
+- Quick-win visual prompting formulas for immediate reuse
+- Prompting methods for presentations, marketing materials, medical imagery, and legal visuals
+- Real-world multimodal examples you can apply in your role
+- Interactive Q&A

--- a/segments/segment-3-ai-notebooks/README.md
+++ b/segments/segment-3-ai-notebooks/README.md
@@ -1,0 +1,9 @@
+# Segment 3: AI Notebooks for Better Insights and Decisions
+
+Learn practical notebook workflows that help you analyze data and report findings with clarity.
+
+## Topics
+- NotebookLM, ChatGPT, and Claude for quick, practical analysis
+- Prompting for clearer reporting in business, healthcare, government, and legal contexts
+- Hands-on notebook prompting techniques you can use today
+- Interactive Q&A

--- a/segments/segment-4-agentic-ai/README.md
+++ b/segments/segment-4-agentic-ai/README.md
@@ -1,0 +1,10 @@
+# Segment 4: Advanced Prompting and Agentic AI
+
+Dive into automation techniques and emerging agentic AI capabilities that streamline repetitive work.
+
+## Topics
+- Automating IT and business tasks with GitHub Copilot, Cursor, Windsurf, and Cline
+- Advanced techniques like Retrieval-Augmented Generation (RAG) and Model Context Protocol (MCP)
+- Demystifying agentic AI: how autonomous agents transform daily workflows
+- Strategies for reliable, hallucination-free results
+- Interactive Q&A and course wrap-up


### PR DESCRIPTION
## Summary
- add comprehensive README with learning outcomes and 4-segment schedule
- scaffold segment folders for course modules
- add code of conduct, contributing guide, issue templates, and PR template
- stage open-source prompt engineering guides and licenses
- provide real-world prompting examples plus framework acronyms and templates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966208a3bc8331bb91345157e07176