### PR TITLE
docs: freshen April 2026 content for currency and lint compliance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,6 +9,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '...'
 3. Scroll down to '...'
@@ -21,6 +22,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
+
 - OS: [e.g. Windows, macOS]
 - Browser [e.g. Chrome, Safari]
 - Version [e.g. 22]

--- a/.github/agents/gpt5-beast-mode.agent.md
+++ b/.github/agents/gpt5-beast-mode.agent.md
@@ -6,46 +6,59 @@ name: 'GPT 5 Beast Mode'
 ---
 
 # Operating principles
+
 - **Beast Mode = Ambitious & agentic.** Operate with maximal initiative and persistence; pursue goals aggressively until the request is fully satisfied. When facing uncertainty, choose the most reasonable assumption, act decisively, and document any assumptions after. Never yield early or defer action when further progress is possible.
 - **High signal.** Short, outcome-focused updates; prefer diffs/tests over verbose explanation.
 - **Safe autonomy.** Manage changes autonomously, but for wide/risky edits, prepare a brief *Destructive Action Plan (DAP)* and pause for explicit approval.
 - **Conflict rule.** If guidance is duplicated or conflicts, apply this Beast Mode policy: **ambitious persistence > safety > correctness > speed**.
 
 ## Tool preamble (before acting)
+
 **Goal** (1 line) → **Plan** (few steps) → **Policy** (read / edit / test) → then call the tool.
 
 ### Tool use policy (explicit & minimal)
+
 **General**
+
 - Default **agentic eagerness**: take initiative after **one targeted discovery pass**; only repeat discovery if validation fails or new unknowns emerge.
 - Use tools **only if local context isn’t enough**. Follow the mode’s `tools` allowlist; file prompts may narrow/expand per task.
 
 **Progress (single source of truth)**
+
 - **manage_todo_list** — establish and update the checklist; track status exclusively here. Do **not** mirror checklists elsewhere.
 
 **Workspace & files**
+
 - **list_dir** to map structure → **file_search** (globs) to focus → **read_file** for precise code/config (use offsets for large files).
 - **replace_string_in_file / multi_replace_string_in_file** for deterministic edits (renames/version bumps). Use semantic tools for refactoring and code changes.
 
 **Code investigation**
+
 - **grep_search** (text/regex), **semantic_search** (concepts), **list_code_usages** (refactor impact).
 - **get_errors** after all edits or when app behavior deviates unexpectedly.
 
 **Terminal & tasks**
+
 - **run_in_terminal** for build/test/lint/CLI; **get_terminal_output** for long runs; **create_and_run_task** for recurring commands.
 
 **Git & diffs**
+
 - **get_changed_files** before proposing commit/PR guidance. Ensure only intended files change.
 
 **Docs & web (only when needed)**
+
 - **fetch** for HTTP requests or official docs/release notes (APIs, breaking changes, config). Prefer vendor docs; cite with title and URL.
 
 **VS Code & extensions**
+
 - **vscodeAPI** (for extension workflows), **extensions** (discover/install helpers), **runCommands** for command invocations.
 
 **GitHub (activate then act)**
+
 - **githubRepo** for pulling examples or templates from public or authorized repos not part of the current workspace.
 
 ## Configuration
+
 <context_gathering_spec>
 Goal: gain actionable context rapidly; stop as soon as you can take effective action.
 Approach: single, focused pass. Remove redundancy; avoid repetitive queries.
@@ -84,26 +97,31 @@ If the host supports Responses API, chain prior reasoning (`previous_response_id
 </responses_api_spec>
 
 ## Anti-patterns
+
 - Multiple context tools when one targeted pass is enough.
 - Forums/blogs when official docs are available.
 - String-replace used for refactors that require semantics.
 - Scaffolding frameworks already present in the repo.
 
 ## Stop conditions (all must be satisfied)
+
 - ✅ Full end-to-end satisfaction of acceptance criteria.
 - ✅ `get_errors` yields no new diagnostics.
 - ✅ All relevant tests pass (or you add/execute new minimal tests).
 - ✅ Concise summary: what changed, why, test evidence, and citations.
 
 ## Guardrails
+
 - Prepare a **DAP** before wide renames/deletes, schema/infra changes. Include scope, rollback plan, risk, and validation plan.
 - Only use the **Network** when local context is insufficient. Prefer official docs; never leak credentials or secrets.
 
 ## Workflow (concise)
+
 1) **Plan** — Break down the user request; enumerate files to edit. If unknown, perform a single targeted search (`search`/`usages`). Initialize **todos**.
 2) **Implement** — Make small, idiomatic changes; after each edit, run **problems** and relevant tests using **runCommands**.
 3) **Verify** — Rerun tests; resolve any failures; only search again if validation uncovers new questions.
 4) **Research (if needed)** — Use **fetch** for docs; always cite sources.
 
 ## Resume behavior
+
 If prompted to *resume/continue/try again*, read the **todos**, select the next pending item, announce intent, and proceed without delay.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,36 +1,43 @@
 # prompt-pro AI Guidance
 
 ## Purpose & Scope
+
 - Main deliverable is the Node demo in [src/index.js](src/index.js) showcasing prompt templates via PromptManager and AIClient
 - Supporting course material lives under [segments](segments), [resources](resources), and [attachments](attachments); keep edits non-destructive
 - Duplicate demo lives in [prompt-template-demo](prompt-template-demo) for standalone use; mirror patterns when adding features
 
 ## Core Node App
+
 - Uses ES modules throughout; export classes/functions explicitly and import with file extensions
 - Prompt orchestration flows: validate config → construct prompts → call OpenAI; follow existing call chain before adding new entrypoints
 - Templates are plain text files in [templates](templates); keep naming kebab-case without extensions when referencing in code
 
 ## Runtime Configuration
+
 - Env vars loaded via dotenv in [src/config.js](src/config.js); copy env.example to .env and set OPENAI_API_KEY before running
 - Azure OpenAI fields are optional but wired through config.azure; guard new code against missing azure settings
 - Retain config validation so missing OPENAI_API_KEY exits immediately; extend validateConfig when introducing new required settings
 
 ## Development Workflow
+
 - Install deps with `npm install`; run the demo with `npm start`, watch mode with `npm run dev`, tests with `npm test`
 - Node 18+ is enforced by package.json engines; prefer language features compatible with that baseline
 - When scripting data transformations, keep helpers in their language-specific folders (e.g., Python utilities in [resources](resources) or [knowledge](knowledge))
 
 ## Prompt Templates & Context
+
 - PromptManager in [src/promptManager.js](src/promptManager.js) caches templates via Map; reuse loadTemplate instead of manual fs reads
 - Context is stored as Map entries merged into template variables; clear or override keys explicitly to avoid stale data
 - manageConversationHistory trims from newest messages first; rely on it for long chats instead of mutating history arrays directly
 
 ## Testing & Quality
+
 - [src/test.js](src/test.js) exercises template loading, substitution, context merge; add cases here when introducing new template features
 - Tests avoid external API calls, so they can run without OpenAI credentials; keep future tests deterministic
 - Logging follows emoji-prefixed messages in existing demos; stay consistent for readability during live sessions
 
 ## Extended Materials
+
 - Large CSV datasets in [attachments](attachments) support workshop exercises; do not rewrite them unless updating official course material
 - Slide extraction scripts like [resources/convert_ppt.py](resources/convert_ppt.py) expect python-pptx; document extra tooling when expanding them
 - High-level prompting guidance resides in [context-engineering.md](context-engineering.md); align new documentation with its terminology

--- a/.github/instructions/markdown-content-instructions.instructions.md
+++ b/.github/instructions/markdown-content-instructions.instructions.md
@@ -23,7 +23,7 @@ Follow these guidelines for formatting and structuring your markdown content:
 
 - **Headings**: Use `##` for H2 and `###` for H3. Ensure that headings are used in a hierarchical manner. Place a blank line before each heading and another blank line after it. Recommend restructuring if content includes H4, and more strongly recommend for H5.
 - **Lists**: Use `-` for bullet points and `1.` for numbered lists. Indent nested lists with two spaces. Insert a blank line before and after each list.
-- **Code Blocks**: Use triple backticks (`) to create fenced code blocks. Specify the language after the opening backticks for syntax highlighting (e.g., `csharp). Leave a blank line before and after each code block.
+- **Code Blocks**: Use triple backticks (`) to create fenced code blocks. Specify the language after the opening backticks for syntax highlighting (e.g.,`csharp). Leave a blank line before and after each code block.
 - **Links**: Use `[link text](URL)` for links. Ensure that the link text is descriptive and the URL is valid.
 - **Images**: Use `![alt text](image URL)` for images. Include a brief description of the image in the alt text. Surround images with blank lines.
 - **Tables**: Use `|` to create tables. Ensure that columns are properly aligned and headers are included. Provide a blank line before and after each table.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,17 @@
 ## Summary
+
 - Lesson / segment touched:
 - Learner outcome improved:
 - Assets updated (docs, templates, demos, etc.):
 
 ## Testing
+
 - [ ] `npm test`
 - [ ] `node src/index.js`
 - [ ] Other (list):
 
 ## Teaching Impact
+
 - [ ] Demo instructions or screenshots included (if UX/content changed)
 - [ ] Risks or caveats called out for facilitators
 - [ ] Security / privacy reviewed per [SECURITY.md](../SECURITY.md)

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+node_modules/
+**/node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,39 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `segments/segment-*` hold the four lesson tracks. Each segment owns its worksheets, demos, and facilitator notes—edit in place rather than inventing new folder layouts.
+
+- `segments/segment-*` hold the four lesson tracks. Each segment owns its worksheets, demos, and facilitator notes - edit in place rather than inventing new folder layouts.
 - `docs/` contains reference material (e.g., `context-engineering.md`) plus the master slide deck (`warner-prompt-pro-december-2025.pptx`). Update these when the narrative shifts.
 - `images/` stores marketing assets, covers, and the GitHub social preview (`social-preview.png`); drop any learner-facing artwork here.
-- `.github/` includes instructions, PR templates, and workflows. `.claude/` and `.vscode/` capture local agent/editor preferences—only tweak when adjusting teaching tooling.
+- `.github/` includes instructions, PR templates, and workflows. `.claude/` and `.vscode/` capture local agent/editor preferences - only tweak when adjusting teaching tooling.
 
 ## Build, Test, and Development Commands
+
 - `npm install` - installs Markdown tooling from `package.json` (markdownlint CLI and helpers).
 - `npx markdownlint-cli2 \"**/*.md\" --config markdownlint.json` - lint all Markdown files using the repo spacing rules.
 - `npx markdownlint-cli2 \"**/*.md\" --config markdownlint.json --fix` - apply safe spacing fixes (run locally before pushing).
 - `python -m http.server` (optional) - spin up a simple server if you want to preview linked assets from `docs/` or `segments/`.
 
 ## Coding Style & Naming Conventions
+
 - Markdown first: keep headings sentence-case, include blank lines around headings and lists (see `markdownlint.json` for enforced spacing).
 - Keep directories kebab-case and prefer descriptive filenames (`segment-3-workflow-multimodal-security/overview.md`).
 - For screenshots or diagrams, export optimized PNGs/JPGs to `images/` and reference them with relative paths in lesson READMEs.
 - Use emoji sparingly in course text; reserve them for callouts or exercises where they aid scannability.
 
 ## Testing Guidelines
+
 - Run the markdownlint command (see above) before opening PRs; the Actions workflow `Markdownlint Autofix` can clean spacing, but manual review avoids noisy diffs.
 - When editing slide decks, export a PDF preview to verify fonts and charts before sharing with learners.
 - For MCP or agent demos inside `segments/segment-4-agentic-orchestration/mcp-demos/`, document manual test steps in the segment README since automated tests are out of scope for this repo.
 
 ## Commit & Pull Request Guidelines
+
 - Follow the existing short, imperative subjects visible in `git log` (e.g., `add warner's laws in advance of Oct 2025 delivery`); mention the delivery window or artifact touched when it adds clarity.
 - Each PR should describe the scenario (new template, segment refresh, demo fix), list test commands run (`npm test`, manual demo), link to any tracking issue, and include screenshots or prompt transcripts if UX is affected.
 
 ## Environment & Security Tips
+
 - Copy `env.example` to `.env` only if you need to demo API-powered workflows; most classroom work relies on external SaaS, not local code.
-- Never commit secrets or participant data—store sanitized assets in `docs/` or `images/` and scrub learner identifiers before upload.
+- Never commit secrets or participant data - store sanitized assets in `docs/` or `images/` and scrub learner identifiers before upload.
 - When sharing logs or MCP transcripts, reference segment filenames and line numbers so facilitators can follow along without exposing private content.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This repo backs Tim Warner's **How to Prompt Like a Pro** O'Reilly Live Learning course (4 × 50 min). It is content-first: Markdown lesson plans inside `segments/`, supporting research and decks in `docs/`, and visual assets in `images/`. There is no top-level application—the root `package.json` is a legacy stub (it references a `src/index.js` that no longer exists). The only runnable code lives under `segments/segment-4-agentic-orchestration/mcp-demos/`.
+This repo backs Tim Warner's **How to Prompt Like a Pro** O'Reilly Live Learning course (4 × 50 min). It is content-first: Markdown lesson plans inside `segments/`, supporting research and decks in `docs/`, and visual assets in `images/`. There is no top-level application - the root `package.json` is a legacy stub (it references a `src/index.js` that no longer exists). The only runnable code lives under `segments/segment-4-agentic-orchestration/mcp-demos/`.
 
 All demo content uses the **Contoso Robotics** scenario (mid-size robotics manufacturer, 500 employees, $120M revenue, Austin TX, CEO Maria Chen). Keep new demo material consistent with this fiction. The course is structured around **Warner's 26 Laws of Generative AI** (`WARNERS-LAWS.md`), split 7-7-8-4 across the four segments.
 
@@ -18,7 +18,7 @@ All demo content uses the **Contoso Robotics** scenario (mid-size robotics manuf
 - `images/` – Cover art and `social-preview.png`. Keep optimized PNG/JPG here.
 - `.github/` – Issue/PR templates, custom instructions, and the `markdownlint-autofix.yml` workflow (runnable on-demand via **Actions → Run workflow**).
 
-Keep existing segment directory names—drop new material into the matching segment rather than introducing parallel folders.
+Keep existing segment directory names - drop new material into the matching segment rather than introducing parallel folders.
 
 ## Authoring Workflow
 
@@ -35,7 +35,7 @@ The only runnable code in the repo. From `segments/segment-4-agentic-orchestrati
 - `npm start` – run the MCP server (`node server.js`).
 - `npm run inspect` – launch MCP Inspector against the local server using `inspector.json`.
 
-Document any manual prerequisites (API keys, network) in that segment's README—do not assume learners can execute code locally.
+Document any manual prerequisites (API keys, network) in that segment's README - do not assume learners can execute code locally.
 
 ## Content Guidelines
 
@@ -43,7 +43,7 @@ Document any manual prerequisites (API keys, network) in that segment's README�
 - Prefer short sections with tables or callouts so lessons are scannable on screen shares.
 - Sentence-case headings; kebab-case directories and filenames.
 - Reserve emoji for callouts and exercises where they aid scannability.
-- Never embed production API keys in lesson text—reference `env.example` and remind learners to set their own environment variables.
+- Never embed production API keys in lesson text - reference `env.example` and remind learners to set their own environment variables.
 - Do not reintroduce the deleted `attachments/` datasets. If sanitized data is required, keep it inside the relevant segment folder with clear provenance.
 
 ## Key Reference Files

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,9 +3,11 @@
 This is a teaching-and-learning space led by Tim Warner for the **Prompt Pro** curriculum. We follow the [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) and reinforce it with classroom-ready expectations.
 
 ## Our Pledge
+
 Tim and every contributor pledge to keep the project, live sessions, and async discussions safe, respectful, and bias-aware so learners can experiment with agentic AI without fear of harassment or dismissal.
 
 ## Our Standards
+
 - Use welcoming and inclusive language that assumes mixed experience levels.
 - Offer feedback that is specific, actionable, and grounded in the repo's teaching goals.
 - Credit ideas, cite training data, and highlight potential risks learners should note.
@@ -13,9 +15,11 @@ Tim and every contributor pledge to keep the project, live sessions, and async d
 - Amplify voices from underrepresented groups and create space for questions before answers.
 
 ## Enforcement
+
 Tim Warner (`tim@techtrainertim.com`) personally reviews conduct reports. Please include links, screenshots, or commit hashes so issues can be resolved quickly and transparently. Tim may engage trusted course moderators for follow-up, but your report will never be publicized without consent.
 
 ## Attribution
+
 Based on the [Contributor Covenant][homepage] with additions tailored to the Prompt Pro classroom.
 
 [homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,13 @@
 Thanks for helping me (Tim Warner) keep this course repo polished and teachable. Every change should make it easier for learners to understand agentic AI patterns, reproduce demos, and adapt the content in their own orgs.
 
 ## Start Here
+
 1. **Review the guides** – skim `README.md`, `AGENTS.md`, and `CODE_OF_CONDUCT.md` to understand expectations for instructors, agents, and students.
 2. **Set up your env** – copy `env.example` to `.env`, add your OpenAI (or Azure OpenAI) keys, and run `npm install`.
 3. **Pick an issue** – choose from the labeled teaching tasks (`good-first-lesson`, `curriculum-update`, `agent-demo`) or open a new issue that explains the instructional value.
 
 ## Workflow
+
 1. Create a topic branch from `main` using a descriptive, kebab-case name (`feature-context-playbook`).
 2. Make small, well-documented commits that explain the learner benefit (e.g., `add retry demo for lesson 4`).
 3. Run `npm test` plus any scenario-specific scripts, and document manual demo steps when automation is not possible.
@@ -18,13 +20,16 @@ Thanks for helping me (Tim Warner) keep this course repo polished and teachable.
    - Any follow-up work for assistants or facilitators
 
 ## Quality Checklist
+
 - Content follows the two-space indentation/camelCase conventions from `src/`.
 - Templates live in `templates/` and are referenced by their stem names.
 - Docs call out teaching tips, prerequisites, and risk considerations.
 - Secrets never land in git history; use `.env` and redact workshop artifacts.
 
 ## Reporting Issues & Asking Questions
+
 Open an issue using the templates or email me directly at `tim@techtrainertim.com` when you need an expedited response (e.g., live session blockers). Please include reproduction steps, expected outcome, and any teaching implications.
 
 ## Code of Conduct
+
 Participation means you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). We are modeling professional, inclusive collaboration for every learner who opens this repo.

--- a/COURSE-PLAN-APRIL-2026.md
+++ b/COURSE-PLAN-APRIL-2026.md
@@ -1,4 +1,4 @@
-# Course Plan: How to Prompt Like a Pro — April 2026
+# Course Plan: How to Prompt Like a Pro - April 2026
 
 **Format:** 4 × 50-min segments, O'Reilly Live Learning
 **Delivery date:** April 2026
@@ -11,16 +11,17 @@
 
 1. You are the pilot; the AI is your co-pilot
 2. Always know who you're signed in as
-3. Beware the anchor trap — draft before you prompt
-4. Trust your gut — never hesitate to second-guess the AI
+3. Beware the anchor trap - draft before you prompt
+4. Trust your gut - never hesitate to second-guess the AI
 5. Every AI chat has its own lifecycle (prompt smell)
 6. The more you disclose in trust, the more the AI can help
 7. Anything you leave out will be inferred
 
 **Demos:**
-- Anchor trap live: audience writes their answer to a business question on paper, THEN we prompt ChatGPT — compare drift
+
+- Anchor trap live: audience writes their answer to a business question on paper, THEN we prompt ChatGPT - compare drift
 - Same prompt in ChatGPT vs Claude vs Gemini: show how omitted context produces three different inferences
-- M365 Copilot: show identity/tenant boundaries — same prompt, different signed-in user, different results
+- M365 Copilot: show identity/tenant boundaries - same prompt, different signed-in user, different results
 
 ---
 
@@ -31,14 +32,15 @@
 8. Surgically sculpt your context
 9. Role play like you're a director
 10. Don't swallow the elephant
-11. Show, don't tell — lead with examples
+11. Show, don't tell - lead with examples
 12. Make the AI show its work
-13. Think meta — prompt about prompting
+13. Think meta - prompt about prompting
 14. Strike while the iron's hot
 
 **Demos:**
-- Few-shot showdown: zero-shot vs 3-example prompt for the same report format in ChatGPT — side by side
-- Chain-of-thought: ask Claude to analyze a budget with and without "think step by step" — compare error rates
+
+- Few-shot showdown: zero-shot vs 3-example prompt for the same report format in ChatGPT - side by side
+- Chain-of-thought: ask Claude to analyze a budget with and without "think step by step" - compare error rates
 - Meta-prompting loop: paste a rough prompt into Gemini, ask it to critique and improve, run the improved version
 
 ---
@@ -49,7 +51,7 @@
 
 15. If you need to remind the AI, add it to custom instructions
 16. Periodically refactor your custom instructions
-17. Treat prompts as assets — version-control them
+17. Treat prompts as assets - version-control them
 18. Use your voice if using words is difficult
 19. Pick up a good book on technical writing
 20. Always have a trusted LLM to cross-reference
@@ -57,10 +59,11 @@
 22. Protect privacy ruthlessly
 
 **Demos:**
+
 - Custom instructions lifecycle: create a ChatGPT Project with custom instructions, refactor them live after a few turns
-- Prompt versioning: show a prompt library in a GitHub repo — diff two versions, show how model updates broke v1
+- Prompt versioning: show a prompt library in a GitHub repo - diff two versions, show how model updates broke v1
 - Voice + vision: dictate a task into Gemini, upload a chart screenshot into Claude, extract data hands-free
-- Privacy audit: show what ChatGPT/Gemini/Copilot store vs delete — walk through each platform's data settings
+- Privacy audit: show what ChatGPT/Gemini/Copilot store vs delete - walk through each platform's data settings
 
 ---
 
@@ -68,16 +71,17 @@
 
 **Laws covered:** 23-26
 
-23. Each LLM has its own personality — match the tool to the task
+23. Each LLM has its own personality - match the tool to the task
 24. Orchestrate subagents as force multipliers
 25. Checkpoint before consequence
 26. Expect breaking changes
 
 **Demos:**
-- LLM personality test: same complex task across ChatGPT, Claude, Gemini — show strengths/weaknesses live
+
+- LLM personality test: same complex task across ChatGPT, Claude, Gemini - show strengths/weaknesses live
 - Claude Code: spin up parallel subagents with git worktrees to refactor, test, and review simultaneously
 - Checkpoint rewind: make a risky change in Claude Code, show checkpoint/rollback in real time
-- Copilot Studio: build a simple multi-agent workflow with a knowledge source in Foundry
+- Copilot Studio: build a simple agent with a file/SharePoint knowledge source and an Escalate handoff
 - MCP weather server: run the live demo from `segments/segment-4-agentic-orchestration/mcp-demos/weather-server/`
 
 ---

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 An **O'Reilly Live Learning** course teaching business professionals how to extract maximum value from AI tools like Microsoft 365 Copilot, ChatGPT, Claude, and Google Gemini.
 
-*Last updated: April 2026*
+*Last updated: June 2026*
 
 ---
 
@@ -27,21 +27,21 @@ An **O'Reilly Live Learning** course teaching business professionals how to extr
 
 1. You are the pilot; the AI is your co-pilot. You're responsible for its actions.
 2. Always know who you're signed in as and who you're chatting with.
-3. Beware the anchor trap — draft before you prompt.
-4. Trust your gut — never hesitate to second-guess the AI.
+3. Beware the anchor trap - draft before you prompt.
+4. Trust your gut - never hesitate to second-guess the AI.
 5. Every AI chat has its own lifecycle; develop your "prompt smell."
 6. The more you disclose in trust, the more the AI can help you.
 7. Anything you leave out of your prompt will be inferred by the AI.
 8. Surgically sculpt your context. Just because you can doesn't mean you should.
 9. Role play like you're a director.
-10. Don't swallow the elephant — break down complex tasks with the AI.
-11. Show, don't tell — lead with examples.
+10. Don't swallow the elephant - break down complex tasks with the AI.
+11. Show, don't tell - lead with examples.
 12. Make the AI show its work.
 13. Think meta: prompt about prompting and custom instructions.
 14. Strike while the iron's hot.
 15. If you need to remind the AI of something, add it to custom instructions.
 16. Periodically refactor your custom instructions and memories.
-17. Treat prompts as assets — version-control them.
+17. Treat prompts as assets - version-control them.
 18. Use your voice if using words is difficult.
 19. Pick up a good book on technical writing.
 20. Always have a trusted LLM to cross-reference responses.
@@ -49,7 +49,7 @@ An **O'Reilly Live Learning** course teaching business professionals how to extr
 22. Protect privacy ruthlessly. Know your chat storage, licensing, and data retention.
 23. Each LLM has its own personality. Match the tool to the task.
 24. Orchestrate subagents as force multipliers. Use git worktrees for parallelism.
-25. Checkpoint before consequence — autonomous does not mean unsupervised.
+25. Checkpoint before consequence - autonomous does not mean unsupervised.
 26. Expect breaking changes. Stay agile, adaptable, and be an eternal learner.
 
 ---
@@ -62,34 +62,38 @@ An **O'Reilly Live Learning** course teaching business professionals how to extr
 | One-off interactions | System-wide reliability |
 | Phrasing and examples | Everything in the context window |
 
-**Key Insight:** Most AI failures aren't model failures—they're context failures.
+**Key Insight:** Most AI failures aren't model failures - they're context failures.
 
 ---
 
 ## Tools Covered
 
 ### Primary Platforms
-- **Microsoft 365 Copilot** — Notebooks, Agents, enterprise integration
-- **ChatGPT** — Projects, Custom GPTs, DALL-E 3, Vision
-- **Google Gemini** — Gems, Imagen 3, 1M+ token context
-- **Claude** — Projects, long-form analysis, Claude Code
+
+- **Microsoft 365 Copilot** - Notebooks, Agents, enterprise integration
+- **ChatGPT** - Projects, Custom GPTs, GPT Image 2, Vision
+- **Google Gemini** - Gems, Imagen 4, 1M+ token context (2M on Gemini 3.5 Pro)
+- **Claude** - Projects, long-form analysis, Claude Code
 
 ### Agentic AI
-- **Claude Code** — Terminal-based autonomous coding with checkpoints
-- **GitHub Copilot Coding Agent** — Issue-to-PR cloud automation
-- **M365 Copilot Studio** — Enterprise multi-agent orchestration
-- **Azure AI Foundry** — Azure-hosted model deployment and orchestration
+
+- **Claude Code** - Terminal-based autonomous coding with checkpoints
+- **GitHub Copilot Coding Agent** - Issue-to-PR cloud automation
+- **M365 Copilot Studio** - Enterprise multi-agent orchestration
+- **Azure AI Foundry** - Azure-hosted model deployment and orchestration
 
 ---
 
 ## Prerequisites
 
 ### Required
+
 - Internet connection
 - ChatGPT free account
 - Google account
 
 ### Recommended
+
 - Microsoft 365 Copilot license
 - Claude Pro
 - GitHub Copilot subscription
@@ -100,6 +104,7 @@ An **O'Reilly Live Learning** course teaching business professionals how to extr
 ## Quick Start
 
 ### CRAFT Framework
+
 ```text
 Context: [situation]
 Role: You are a [role]
@@ -109,6 +114,7 @@ Tone: [voice/style]
 ```
 
 ### Example Prompt
+
 ```text
 Context: I'm preparing a quarterly business review for my VP.
 Role: You are a senior business analyst.
@@ -121,7 +127,7 @@ Tone: Professional and data-driven.
 
 ## Repository Structure
 
-```
+```text
 docs/                               # Reference guides + slide deck
 images/                             # Cover art, social preview assets
 segments/
@@ -152,9 +158,11 @@ COURSE-PLAN-APRIL-2026.md          # April 2026 delivery plan
 Licensed under [MIT](LICENSE). See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [AGENTS.md](AGENTS.md) for the agent-focused repository playbook.
 
 ### Code of Conduct
+
 Participation in this project is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ### Security
+
 Found a vulnerability or risky prompt scenario? Follow the disclosure steps in [SECURITY.md](SECURITY.md) or email Tim directly at `tim@techtrainertim.com`.
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,15 +13,17 @@ Prompt Pro is a teaching repository, but we still treat security seriously so le
 
 1. **Email Tim Warner directly** at `tim@techtrainertim.com` with the subject line `Prompt Pro Security`.
 2. Include:
-   - Steps to reproduce (commands, environment, sample data)
-   - Potential impact on learners (e.g., secret leakage, unsafe prompt, dependency risk)
-   - Suggested remediation or temporary mitigation tips we can teach during class
+
+- Steps to reproduce (commands, environment, sample data)
+- Potential impact on learners (e.g., secret leakage, unsafe prompt, dependency risk)
+- Suggested remediation or temporary mitigation tips we can teach during class
+
 3. Please avoid opening public issues until Tim acknowledges receipt. I aim to respond within **2 business days** and coordinate a fix or advisory shortly thereafter.
 
 ## Disclosure Expectations
 
 - Do not test against production services you do not own; limit research to the repo and its sample assets.
-- Never share real participant data in reports—use sanitized samples or reference fictional personas.
+- Never share real participant data in reports - use sanitized samples or reference fictional personas.
 - If you find a vulnerability during a live session, notify the facilitator privately so we can keep the classroom experience constructive.
 
 Thank you for helping keep this learning environment safe and exemplary for the community.

--- a/WARNERS-LAWS.md
+++ b/WARNERS-LAWS.md
@@ -22,13 +22,13 @@ Understand which account, organization, and data boundaries you're operating wit
 
 ## Mindset & Cognition
 
-### Law #3: Beware the anchor trap — draft before you prompt
+### Law #3: Beware the anchor trap - draft before you prompt
 
 **Principle**: Preserve independent judgment.
 
-Write your own answer sketch before you prompt. Once the AI sets the frame, your edits orbit its version, not yours. The first AI output becomes a psychological anchor you can't unsee — drafting first keeps your thinking genuinely independent.
+Write your own answer sketch before you prompt. Once the AI sets the frame, your edits orbit its version, not yours. The first AI output becomes a psychological anchor you can't unsee - drafting first keeps your thinking genuinely independent.
 
-### Law #4: Trust your gut — never hesitate to second-guess the AI
+### Law #4: Trust your gut - never hesitate to second-guess the AI
 
 **Principle**: Human intuition is a feature, not a bug.
 
@@ -36,7 +36,7 @@ If something the AI produces feels off, it probably is. Your domain expertise an
 
 ### Law #5: Every AI chat has its own lifecycle
 
-**Principle**: Develop "prompt smell" — know when to start fresh.
+**Principle**: Develop "prompt smell" - know when to start fresh.
 
 Recognize when conversation context becomes polluted, contradictory, or unfocused. Start a new thread rather than fighting accumulated confusion.
 
@@ -78,7 +78,7 @@ Frame requests with specific roles and responsibilities. "Act as a senior DevOps
 
 Decompose large problems into smaller, sequential steps. AI works best with focused, well-scoped requests rather than overwhelming complexity.
 
-### Law #11: Show, don't tell — lead with examples
+### Law #11: Show, don't tell - lead with examples
 
 **Principle**: Few-shot prompting outperforms instructions alone.
 
@@ -90,7 +90,7 @@ Providing two to five concrete examples of the output you want consistently beat
 
 For any multi-step or analytical task, explicitly instruct the model to reason step by step before giving a final answer. Asking it to think aloud dramatically reduces confident-sounding errors on anything comparative, numerical, or logical.
 
-### Law #13: Think meta — prompt about prompting
+### Law #13: Think meta - prompt about prompting
 
 **Principle**: Use the AI to improve your own prompts.
 
@@ -104,7 +104,7 @@ Ask the AI how to improve your prompts. Request feedback on your question struct
 
 **Principle**: Capture ideas when they emerge.
 
-Document insights, prompts, and patterns immediately. Context and momentum are perishable — record them while fresh.
+Document insights, prompts, and patterns immediately. Context and momentum are perishable - record them while fresh.
 
 ### Law #15: If you need to remind the AI, add it to custom instructions
 
@@ -118,11 +118,11 @@ Persistent preferences and constraints belong in custom instructions, not repeat
 
 Review and update your instructions as your needs evolve. Remove outdated guidance, add new patterns, and consolidate redundancies.
 
-### Law #17: Treat prompts as assets — version-control them
+### Law #17: Treat prompts as assets - version-control them
 
 **Principle**: Prompt drift is a regression risk.
 
-The difference between a good prompt and a great prompt is usually a dozen small edits. Name your prompts, date them, note what changed. High-value prompts are organizational IP — version-control them and test them against model updates the same way you'd test software after a dependency upgrade.
+The difference between a good prompt and a great prompt is usually a dozen small edits. Name your prompts, date them, note what changed. High-value prompts are organizational IP - version-control them and test them against model updates the same way you'd test software after a dependency upgrade.
 
 ---
 
@@ -170,13 +170,13 @@ Never paste personal, confidential, or customer data into public or free-tier AI
 
 **Principle**: Platform-specific approaches.
 
-Different models excel at different tasks. Claude handles nuance well, GPT-4 has broad knowledge, DeepSeek is cost-effective for coding. Match the tool to the task.
+Different models excel at different tasks. Claude handles nuance well, GPT-5.x has broad knowledge, DeepSeek is cost-effective for coding. Match the tool to the task.
 
 ### Law #24: Orchestrate subagents as force multipliers
 
 **Principle**: Delegate, parallelize, and conquer.
 
-If your environment supports subagents, use them. Spin up specialized agents for security review, code analysis, testing, and documentation in parallel rather than working through tasks sequentially. Use git worktrees for multi-level parallelism so agents operate on isolated copies without blocking each other. The best prompt engineers don't just talk to one AI — they conduct an orchestra.
+If your environment supports subagents, use them. Spin up specialized agents for security review, code analysis, testing, and documentation in parallel rather than working through tasks sequentially. Use git worktrees for multi-level parallelism so agents operate on isolated copies without blocking each other. The best prompt engineers don't just talk to one AI - they conduct an orchestra.
 
 ### Law #25: Checkpoint before consequence
 
@@ -218,4 +218,4 @@ _These laws are derived from practical experience teaching thousands of professi
 
 **Author**: Tim Warner
 **Version**: 2.0
-**Last Updated**: April 2026
+**Last Updated**: June 2026

--- a/docs/INSTRUCTOR-MANIFEST.md
+++ b/docs/INSTRUCTOR-MANIFEST.md
@@ -9,6 +9,7 @@ Quick navigation guide for delivering the 4-segment O'Reilly Live Learning cours
 ## Pre-Flight Checklist
 
 ### Accounts to Have Open
+
 - [ ] Microsoft 365 Copilot (with Notebooks access)
 - [ ] ChatGPT Plus (logged in, Project ready)
 - [ ] Google Gemini Advanced
@@ -17,6 +18,7 @@ Quick navigation guide for delivering the 4-segment O'Reilly Live Learning cours
 - [ ] VS Code with GitHub Copilot extension
 
 ### Demo Files Ready
+
 - Sample documents for Notebook demos (quarterly reports, proposals)
 - Code screenshots for vision demos
 - Sample repo with `.github/copilot-instructions.md`
@@ -25,6 +27,7 @@ Quick navigation guide for delivering the 4-segment O'Reilly Live Learning cours
 ---
 
 ## Segment 1: Core Prompting & Context Engineering
+
 **File:** [segments/segment-1-identity-mindset-context/README.md](segments/segment-1-identity-mindset-context/README.md)
 
 ### Teaching Flow (50 min)
@@ -40,18 +43,21 @@ Quick navigation guide for delivering the 4-segment O'Reilly Live Learning cours
 | 45-50 | Q&A + Hands-on time | Attendees try CRAFT on their own task |
 
 ### Key Demos to Prepare
+
 1. **M365 Copilot Notebook**: Pre-load 3-5 quarterly reports, demo cross-document synthesis
 2. **ChatGPT Project**: Show custom instructions + file upload workflow
 3. **Gemini**: Show 1M token context handling with large document
 
 ### Talking Points
-- "Most AI failures aren't model failures—they're context failures"
+
+- "Most AI failures aren't model failures - they're context failures"
 - Warner's Laws: "Anything you leave out will be inferred"
 - Show the difference: same prompt, with vs. without context grounding
 
 ---
 
 ## Segment 2: Multimodal Prompting & AI-Assisted Coding
+
 **File:** [segments/segment-2-context-sculpting-technique/README.md](segments/segment-2-context-sculpting-technique/README.md)
 
 ### Teaching Flow (50 min)
@@ -66,18 +72,21 @@ Quick navigation guide for delivering the 4-segment O'Reilly Live Learning cours
 | 45-50 | Q&A + Hands-on | Attendees set up their own instruction file |
 
 ### Key Demos to Prepare
+
 1. **Image Generation**: Same prompt ("team collaborating in modern office") across 3 tools
 2. **Vision**: Upload a chart image, extract data to markdown table
 3. **GitHub Copilot**: Show a repo with `.github/copilot-instructions.md` and demo the `#` prompt menu
 
 ### Talking Points
-- Text-in-image: Gemini Imagen 3 wins for accuracy
+
+- Text-in-image: Gemini Imagen 4 wins for accuracy
 - Vision analysis saves hours of manual data extraction
 - Copilot instruction files = context engineering for code
 
 ---
 
-## Segment 3: AI Workspaces—Notebooks, Projects, and Custom Assistants
+## Segment 3: AI Workspaces - Notebooks, Projects, and Custom Assistants
+
 **File:** [segments/segment-3-workflow-multimodal-security/README.md](segments/segment-3-workflow-multimodal-security/README.md)
 
 ### Teaching Flow (50 min)
@@ -93,22 +102,26 @@ Quick navigation guide for delivering the 4-segment O'Reilly Live Learning cours
 | 45-50 | Q&A + Comparison discussion | When to use what? |
 
 ### Key Demos to Prepare
+
 1. **M365 Notebook**: Pre-loaded with 5+ documents, show Audio Overview generation
 2. **ChatGPT Project**: Create "Marketing Campaign" project with custom instructions
 3. **Gemini Gem**: Create "Writing Editor" gem with style preferences
 4. **Custom GPT**: Show the Contract Review Assistant configuration
 
 ### Talking Points
+
 - Notebooks = analysis power; Projects = workflow continuity
 - Custom instructions are the secret weapon for consistency
 - M365 Agents can orchestrate multi-step enterprise workflows
 
 ### Sample Knowledge Files
+
 - `segments/segment-3-workflow-multimodal-security/knowledge/choose-an-agile-approach/` - Use this as example content for Notebook demo
 
 ---
 
-## Segment 4: Agentic AI—Autonomous Coding and Enterprise Agents
+## Segment 4: Agentic AI - Autonomous Coding and Enterprise Agents
+
 **File:** [segments/segment-4-agentic-orchestration/README.md](segments/segment-4-agentic-orchestration/README.md)
 
 ### Teaching Flow (50 min)
@@ -123,16 +136,19 @@ Quick navigation guide for delivering the 4-segment O'Reilly Live Learning cours
 | 42-50 | Course Wrap-up + Q&A | Key takeaways, next steps |
 
 ### Key Demos to Prepare
+
 1. **Claude Code**: Run `claude "Add a simple feature..."` in terminal, show checkpoint/rewind
 2. **GitHub Copilot Agent**: Have an issue ready to assign to @copilot (or show session view)
 3. **MCP Server**: Weather server in `segments/segment-4-agentic-orchestration/mcp-demos/weather-server/`
 
 ### Talking Points
+
 - Claude Code = terminal-first, sandboxed, checkpoint safety
 - GitHub Copilot Agent = cloud-based, issue-driven, validates with your tests
 - MCP = the standard for persistent AI memory (Anthropic + Microsoft)
 
 ### MCP Demo Setup
+
 ```bash
 cd segments/segment-4-agentic-orchestration/mcp-demos/weather-server
 npm install
@@ -159,13 +175,16 @@ npm install
 ## Segment Transitions
 
 ### After Segment 1 → 2
+
 "Now that you understand how to engineer context in your prompts, let's go beyond text. We'll see how these same principles apply to images and code."
 
 ### After Segment 2 → 3
+
 "You've seen how to prompt for images and configure Copilot. Now let's build persistent workspaces that remember your context across sessions."
 
 ### After Segment 3 → 4
-"You've mastered workspaces and custom assistants. Now let's hand over the wheel entirely—autonomous agents that work while you focus elsewhere."
+
+"You've mastered workspaces and custom assistants. Now let's hand over the wheel entirely - autonomous agents that work while you focus elsewhere."
 
 ---
 

--- a/docs/context-engineering-guide.md
+++ b/docs/context-engineering-guide.md
@@ -1,7 +1,8 @@
 # Context Engineering: Beyond Prompts
-## A Feynman-Style Guide to Feeding AI Brains (December 2025)
 
-> **"Context engineering is prompt engineering's wiser older sibling."** — The AI community, 2025
+## A Feynman-Style Guide to Feeding AI Brains (June 2026)
+
+> **"Context engineering is prompt engineering's wiser older sibling."** - The AI community, 2025
 
 ---
 
@@ -12,7 +13,7 @@
 Prompt engineering asks: "How do I phrase my question?"
 Context engineering asks: "What does the AI need to know to give me a great answer?"
 
-> *"Building with language models is becoming less about finding the right words and more about answering: what configuration of context is most likely to generate our desired behavior?"* — [Anthropic](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+> *"Building with language models is becoming less about finding the right words and more about answering: what configuration of context is most likely to generate our desired behavior?"* - [Anthropic](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
 
 ---
 
@@ -24,7 +25,7 @@ As [Andrej Karpathy](https://blog.langchain.com/context-engineering-for-agents/)
 
 Just like your computer can only work with what's loaded in RAM, an LLM can only work with what's in its context window. Context engineering is like being the operating system that decides what gets loaded.
 
-**The core problem:** Context windows are finite (8K to 200K tokens typically). You can't dump everything in. You must be strategic.
+**The core problem:** Context windows are finite (commonly 200K to 1M+ tokens; some models now reach 2M). You can't dump everything in. You must be strategic.
 
 ---
 
@@ -33,33 +34,41 @@ Just like your computer can only work with what's loaded in RAM, an LLM can only
 According to [LlamaIndex](https://www.llamaindex.ai/blog/context-engineering-what-it-is-and-techniques-to-consider), context engineering boils down to four core strategies:
 
 ### 1. Write
+
 Create new context that didn't exist before.
 
 **Examples:**
+
 - System prompts that define behavior
 - Summary documents of long conversations
 - Procedural instructions ("memories" the AI can reference)
 
 ### 2. Select
+
 Choose which existing information to include.
 
 **Examples:**
-- RAG (Retrieval-Augmented Generation) — pulling relevant docs
+
+- RAG (Retrieval-Augmented Generation) - pulling relevant docs
 - Selecting which conversation history to keep
 - Picking relevant few-shot examples
 
 ### 3. Compress
+
 Reduce information while preserving meaning.
 
 **Examples:**
+
 - Summarizing long documents
 - Trimming older messages from chat history
 - Extracting key facts from verbose sources
 
 ### 4. Isolate
+
 Separate contexts across different processes.
 
 **Examples:**
+
 - Multi-agent systems where each agent has its own context
 - Sandboxed sub-tasks with focused context
 - Separate "workspaces" for different topics
@@ -71,12 +80,13 @@ Separate contexts across different processes.
 **RAG (Retrieval-Augmented Generation)** was the first widely adopted context engineering technique. It solves a fundamental problem: LLMs only know what they were trained on.
 
 **How RAG works:**
+
 1. **User asks a question**
 2. **System searches** a knowledge base for relevant documents
 3. **Relevant chunks** are added to the prompt
 4. **LLM answers** using both its training AND the retrieved context
 
-```
+```text
 [Retrieved Context]
 From Company Handbook (page 47): Vacation policy allows 20 days PTO annually...
 
@@ -86,9 +96,9 @@ How many vacation days do I get?
 [LLM can now answer accurately for YOUR company]
 ```
 
-**Why it matters:** RAG lets you introduce information the LLM was never trained on—your company docs, recent events, specialized knowledge.
+**Why it matters:** RAG lets you introduce information the LLM was never trained on - your company docs, recent events, specialized knowledge.
 
-> *"Context engineering arguably started with RAG systems... RAG was one of the first techniques that let you introduce LLMs to information that wasn't part of their original training data."* — [LlamaIndex](https://www.llamaindex.ai/blog/context-engineering-what-it-is-and-techniques-to-consider)
+> *"Context engineering arguably started with RAG systems... RAG was one of the first techniques that let you introduce LLMs to information that wasn't part of their original training data."* - [LlamaIndex](https://www.llamaindex.ai/blog/context-engineering-what-it-is-and-techniques-to-consider)
 
 ---
 
@@ -108,6 +118,7 @@ Long-term memory = information that persists across conversations
 ### Practical Implementation
 
 Most SaaS LLMs now offer built-in memory features:
+
 - **ChatGPT:** Memory feature stores facts across chats
 - **Claude:** Projects with uploaded files persist context
 - **Gemini:** Workspace integration remembers document context
@@ -121,6 +132,7 @@ Most SaaS LLMs now offer built-in memory features:
 More context isn't always better. [Drew Breunig](https://www.datacamp.com/blog/context-engineering) identified three ways context can hurt:
 
 ### Context Poisoning
+
 A hallucination or error makes it into the context and perpetuates.
 
 **Example:** AI incorrectly states "the deadline is March 15" in conversation. This gets saved to memory. Future questions about deadlines get wrong answers.
@@ -128,6 +140,7 @@ A hallucination or error makes it into the context and perpetuates.
 **Fix:** Validate important information before it becomes persistent context.
 
 ### Context Distraction
+
 Irrelevant information overwhelms relevant information.
 
 **Example:** You dump a 100-page document into context, but only 2 pages are relevant. The AI struggles to find the signal in the noise.
@@ -135,13 +148,14 @@ Irrelevant information overwhelms relevant information.
 **Fix:** Be selective. Pre-filter documents. Use chunking strategies that surface relevance.
 
 ### Context Confusion
+
 Contradictory information in context leads to inconsistent responses.
 
 **Example:** Two documents in context give different procedures for the same task. AI doesn't know which to follow.
 
 **Fix:** Curate context for consistency. Resolve contradictions before insertion.
 
-> *"Good context engineering means finding the smallest possible set of high-signal tokens that maximize the likelihood of some desired outcome."* — [Anthropic](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+> *"Good context engineering means finding the smallest possible set of high-signal tokens that maximize the likelihood of some desired outcome."* - [Anthropic](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
 
 ---
 
@@ -172,6 +186,7 @@ Contradictory information in context leads to inconsistent responses.
 ```
 
 **Why structure matters:**
+
 - Clear sections prevent blending/confusion
 - Makes it easier to update specific parts
 - Models can better "attend" to relevant sections
@@ -184,9 +199,10 @@ Contradictory information in context leads to inconsistent responses.
 When context exceeds limits, you must compress. Here are the main approaches:
 
 ### Summarization
+
 Use an LLM to distill key information.
 
-```
+```text
 Before: [50,000 token document]
 After: [500 token summary of key points]
 ```
@@ -194,23 +210,26 @@ After: [500 token summary of key points]
 **Trade-off:** Lossy. Details are lost. Good for gist, bad for specifics.
 
 ### Trimming
+
 Remove older or less relevant content.
 
-```
+```text
 Strategy: Keep last N messages, summarize older ones
 Strategy: Keep messages mentioning key entities, drop small talk
 ```
 
 ### Selective Retrieval
-Don't include everything—include what's relevant.
 
-```
+Don't include everything - include what's relevant.
+
+```text
 Query: "What's the refund policy?"
 Retrieve: Only sections about refunds
 Skip: Shipping, FAQs about unrelated topics
 ```
 
 ### Advanced: MemAgent
+
 [Recent research](https://www.llamaindex.ai/blog/context-engineering-what-it-is-and-techniques-to-consider) shows systems like MemAgent that dynamically compress context, using reinforcement learning to decide what to keep in a fixed "memory slot."
 
 ---
@@ -226,7 +245,7 @@ One of the most powerful context engineering patterns: **split context across sp
 
 Instead of one agent with everything in context:
 
-```
+```text
 ┌─────────────────────────────────────────────────┐
 │ Orchestrator Agent                              │
 │ (Routes tasks, synthesizes results)             │
@@ -240,6 +259,7 @@ Instead of one agent with everything in context:
 ```
 
 Each agent has:
+
 - Focused context relevant to its task
 - Specific tools it can use
 - Clear boundaries
@@ -254,7 +274,7 @@ Each agent has:
 
 Before a complex task, create a briefing:
 
-```
+```text
 I'm going to work on [project]. Here's what you need to know:
 
 **Background:**
@@ -276,7 +296,7 @@ Acknowledge you understand before we proceed.
 
 For long conversations, periodically refresh context:
 
-```
+```text
 Let me summarize where we are:
 - We decided on [X]
 - We ruled out [Y] because [reason]
@@ -289,7 +309,7 @@ Is this accurate? Any corrections before we continue?
 
 When switching tasks within a conversation:
 
-```
+```text
 New task. For this, focus only on:
 - [Relevant context A]
 - [Relevant context B]
@@ -303,7 +323,7 @@ Task: [specific request]
 
 When responses seem off:
 
-```
+```text
 What context are you using to answer? List:
 1. Key facts you're relying on
 2. Assumptions you're making
@@ -321,10 +341,11 @@ According to the [July 2025 Context Engineering Survey](https://arxiv.org/abs/25
 > *"Best performance comes from modular architectures combining multiple techniques (retrieval, memory, tool use)."*
 
 **Key findings:**
-1. **Hybrid approaches win** — Combine RAG + memory + compression
-2. **Structure beats volume** — Organized context outperforms more context
-3. **Task-specific context** — Different tasks need different context configurations
-4. **Continuous refinement** — Context engineering requires ongoing evaluation
+
+1. **Hybrid approaches win** - Combine RAG + memory + compression
+2. **Structure beats volume** - Organized context outperforms more context
+3. **Task-specific context** - Different tasks need different context configurations
+4. **Continuous refinement** - Context engineering requires ongoing evaluation
 
 ---
 
@@ -356,14 +377,14 @@ Before sending a prompt, ask:
 
 ## Key Takeaways
 
-1. **Context > Phrasing** — What you include matters more than how you ask
-2. **Less is often more** — Curated context beats comprehensive dumps
-3. **Structure is free clarity** — Use sections, tags, clear organization
-4. **Watch for pollution** — Bad context perpetuates bad answers
-5. **Think like an OS** — You're the memory manager for the AI's RAM
+1. **Context > Phrasing** - What you include matters more than how you ask
+2. **Less is often more** - Curated context beats comprehensive dumps
+3. **Structure is free clarity** - Use sections, tags, clear organization
+4. **Watch for pollution** - Bad context perpetuates bad answers
+5. **Think like an OS** - You're the memory manager for the AI's RAM
 
 ---
 
-*Last updated: December 2025*
+*Last updated: June 2026*
 
-*Sources verified: All hyperlinks validated December 2025*
+*Sources verified: All hyperlinks validated June 2026*

--- a/docs/context-engineering.md
+++ b/docs/context-engineering.md
@@ -4,7 +4,7 @@
 
 ## 🎯 Overview
 
-This document curates **verified, current guidance** for crafting effective prompts for Large Language Models (LLMs). Whether you're an end-user crafting prompts for daily tasks or a developer architect building AI-powered solutions, these resources represent the **state-of-the-art** in prompt engineering as of 2024.
+This document curates **verified, current guidance** for crafting effective prompts for Large Language Models (LLMs). Whether you're an end-user crafting prompts for daily tasks or a developer architect building AI-powered solutions, these resources represent the **state-of-the-art** in prompt engineering as of 2026.
 
 ---
 
@@ -13,7 +13,7 @@ This document curates **verified, current guidance** for crafting effective prom
 ### **Core Principles & Fundamentals**
 
 - **[OpenAI's Prompt Engineering Guide](https://platform.openai.com/docs/guides/prompt-engineering)** - The official, comprehensive guide from OpenAI covering basic to advanced techniques
-- **[Anthropic's Prompt Engineering Guide](https://docs.anthropic.com/claude/docs/prompt-engineering)** - Claude's official documentation with safety-focused approaches
+- **[Anthropic's Prompt Engineering Guide](https://docs.claude.com/claude/docs/prompt-engineering)** - Claude's official documentation with safety-focused approaches
 - **[Microsoft's Prompt Engineering Best Practices](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/prompt-engineering)** - Enterprise-focused guidance for Azure OpenAI Service
 
 ### **Advanced Techniques**
@@ -91,7 +91,7 @@ This document curates **verified, current guidance** for crafting effective prom
 
 - **[Microsoft's AI Learning Path](https://learn.microsoft.com/en-us/training/paths/ai-fundamentals/)** - Comprehensive AI fundamentals
 - **[OpenAI's API Documentation](https://platform.openai.com/docs)** - Complete API reference with examples
-- **[Anthropic's Claude Documentation](https://docs.anthropic.com/)** - Claude-specific guidance
+- **[Anthropic's Claude Documentation](https://docs.claude.com/)** - Claude-specific guidance
 
 ### **Structured Learning**
 
@@ -146,12 +146,14 @@ This document curates **verified, current guidance** for crafting effective prom
 ## 🎯 Tim's Pro Tips
 
 ### **For End Users:**
+
 - **Start simple** - Complex prompts often fail more than simple ones
 - **Test iteratively** - Small changes can have big impacts
 - **Use examples** - Few-shot prompting is incredibly powerful
 - **Be specific** - Vague prompts get vague results
 
 ### **For Developers:**
+
 - **Design for failure** - LLMs are probabilistic, not deterministic
 - **Implement retry logic** - Network issues and rate limits happen
 - **Use structured outputs** - Function calling is your friend
@@ -161,7 +163,7 @@ This document curates **verified, current guidance** for crafting effective prom
 
 ## 📝 Last Updated
 
-**December 2024** - This document is maintained to reflect the current state of prompt engineering best practices. Links are verified and tested regularly.
+**June 2026** - This document is maintained to reflect the current state of prompt engineering best practices. Links are verified and tested regularly.
 
 ---
 

--- a/docs/practical-examples-chatgpt.md
+++ b/docs/practical-examples-chatgpt.md
@@ -1,7 +1,8 @@
 # Practical Prompting: ChatGPT
-## Real-World Examples for OpenAI's ChatGPT (December 2025)
 
-> **"AI engineering is inherently an empirical discipline—build informative evals and iterate often."** — [OpenAI](https://cookbook.openai.com/examples/gpt4-1_prompting_guide)
+## Real-World Examples for OpenAI's ChatGPT (June 2026)
+
+> **"AI engineering is inherently an empirical discipline - build informative evals and iterate often."** - [OpenAI](https://cookbook.openai.com/examples/gpt4-1_prompting_guide)
 
 ---
 
@@ -9,21 +10,24 @@
 
 **What it is:** OpenAI's conversational AI, available via chat.openai.com (consumer) and API (developers).
 
-**Current models (Dec 2025):**
-- **GPT-5.1** — Latest flagship with parallel tool execution
-- **GPT-5** — Previous flagship
-- **GPT-4o** — Multimodal (text, vision, audio)
+**Current models (June 2026):**
+
+- **GPT-5.5** - Latest flagship with parallel tool execution
+- **GPT-5.x** - Prior flagship releases
+- **GPT-4o** - Legacy multimodal (text, vision, audio)
 
 **Key strengths:**
+
 - Excellent instruction following
 - Strong coding capabilities
 - Multimodal (can see images, hear audio)
 - Built-in tools (web search, code execution, image generation)
 
 **Official Resources:**
+
 - [OpenAI Prompt Engineering Guide](https://platform.openai.com/docs/guides/prompt-engineering)
 - [ChatGPT Best Practices](https://help.openai.com/en/articles/10032626-prompt-engineering-best-practices-for-chatgpt)
-- [GPT-5.1 Prompting Guide](https://cookbook.openai.com/examples/gpt-5/gpt-5-1_prompting_guide)
+- [GPT-5.5 Prompting Guide](https://cookbook.openai.com/examples/gpt-5/gpt-5-1_prompting_guide)
 
 ---
 
@@ -34,16 +38,18 @@ From [OpenAI Academy](https://academy.openai.com/public/clubs/work-users-ynjqu/r
 > *"Prompt engineering is the process of designing and refining your input in a way that helps ChatGPT give the best possible answer."*
 
 **Three principles:**
-1. **Be specific, but keep it simple** — Detail matters, but focus on what's essential
-2. **Break big tasks into smaller steps** — Easier for ChatGPT to give focused answers
-3. **Iterate, don't restart** — Build on responses rather than starting over
+
+1. **Be specific, but keep it simple** - Detail matters, but focus on what's essential
+2. **Break big tasks into smaller steps** - Easier for ChatGPT to give focused answers
+3. **Iterate, don't restart** - Build on responses rather than starting over
 
 ---
 
 ## Example 1: Code Review
 
 ### Basic Prompt (Gets Okay Results)
-```
+
+```text
 Review this code for bugs.
 
 def calculate_total(items):
@@ -54,7 +60,8 @@ def calculate_total(items):
 ```
 
 ### Better Prompt (Gets Great Results)
-```
+
+```text
 You are a senior Python developer doing a code review.
 
 Review this function for:
@@ -73,10 +80,12 @@ def calculate_total(items):
 ```
 
 Format your response as:
+
 - **Issues Found:** [bullet list]
 - **Suggested Fix:** [code block]
 - **Explanation:** [1-2 sentences per fix]
-```
+
+```text
 
 **Why it's better:**
 - Role sets expertise level
@@ -89,26 +98,32 @@ Format your response as:
 
 ### Basic Prompt
 ```
+
 Write an email declining a meeting.
-```
+
+```text
 
 ### Better Prompt
 ```
+
 Write a professional email with these parameters:
 
 **Purpose:** Decline a meeting invitation
 **Recipient:** External vendor (formal relationship)
 **Tone:** Polite but firm
 **Key points to include:**
+
 - Schedule conflict (don't specify details)
 - Offer to reschedule next week
 - Suggest they send materials in advance
 
 **Constraints:**
+
 - 3 short paragraphs maximum
 - No apologetic language ("I'm so sorry...")
 - End with a clear call to action
-```
+
+```text
 
 **Output Quality:** The second prompt produces a focused, professional email that matches your communication style.
 
@@ -123,18 +138,22 @@ Analyze a CSV of sales data.
 
 ### Effective Prompt
 ```
+
 I've uploaded sales_data.csv. Please:
 
 1. **Explore:** Show me the first 5 rows and basic statistics
 2. **Clean:** Identify and handle any missing values
 3. **Analyze:**
-   - Total revenue by product category
-   - Monthly trend over the past year
-   - Top 5 customers by purchase volume
+
+- Total revenue by product category
+- Monthly trend over the past year
+- Top 5 customers by purchase volume
+
 4. **Visualize:** Create charts for #3
 
 After each step, explain what you found before moving to the next.
-```
+
+```text
 
 **Why this works:**
 - Structured steps let you verify each stage
@@ -148,17 +167,21 @@ After each step, explain what you found before moving to the next.
 ### The Feynman Technique via ChatGPT
 
 ```
+
 Explain [concept] to me using the Feynman technique:
 
 1. Start with a simple analogy a high schooler would understand
 2. Then build up complexity in 3 levels:
-   - Level 1: Core idea (2-3 sentences)
-   - Level 2: How it works (1 paragraph)
-   - Level 3: Technical details (for practitioners)
+
+- Level 1: Core idea (2-3 sentences)
+- Level 2: How it works (1 paragraph)
+- Level 3: Technical details (for practitioners)
+
 3. End with a "test your understanding" question
 
 Concept: Kubernetes container orchestration
-```
+
+```text
 
 **Variations:**
 - "Explain like I'm switching careers from [field A] to [field B]"
@@ -171,26 +194,32 @@ Concept: Kubernetes container orchestration
 
 ### Basic Prompt
 ```
+
 Summarize this article.
-```
+
+```text
 
 ### Better Prompt
 ```
+
 Summarize this article for a busy executive:
 
 **Format:**
+
 - **TL;DR:** [1 sentence, the absolute key point]
 - **Key Findings:** [3-5 bullets, most important facts]
 - **So What:** [Why this matters, implications]
 - **Action Items:** [What someone should do with this info]
 
 **Constraints:**
+
 - Total length: Under 200 words
 - No jargon unless defined
 - Flag any claims that seem unsubstantiated
 
 [paste article]
-```
+
+```text
 
 ---
 
@@ -201,22 +230,26 @@ Open-ended "give me ideas" prompts produce generic results.
 
 ### Better Approach
 ```
+
 Generate 10 marketing campaign ideas for [product].
 
 **Constraints to force creativity:**
+
 - Budget: Under $5,000
 - Timeline: 2 weeks
 - Can't use: Paid social ads, influencers
 - Must include: User-generated content component
 
 **For each idea, provide:**
+
 1. Campaign name (catchy)
 2. One-sentence description
 3. Why it might work
 4. Biggest risk
 
 Start with your most unconventional idea.
-```
+
+```text
 
 **Why constraints help:** They force the model out of generic territory and into creative problem-solving.
 
@@ -229,6 +262,7 @@ Research a topic thoroughly.
 
 ### Prompt Structure
 ```
+
 Help me research [topic]. Let's do this systematically:
 
 **Phase 1: Scope**
@@ -237,6 +271,7 @@ What are the 5 key questions someone researching this should answer?
 
 **Phase 2: Deep Dive**
 For each question:
+
 - Current consensus/answer
 - Key debates or uncertainties
 - Most cited sources
@@ -245,7 +280,8 @@ For each question:
 Create a 1-page briefing document I could share with my team.
 
 Let's start with Phase 1.
-```
+
+```text
 
 **Why multi-phase works:**
 - Prevents overwhelming single responses
@@ -260,10 +296,12 @@ Let's start with Phase 1.
 ChatGPT can remember facts across conversations.
 
 ```
+
 Remember: I'm a Python developer working on a Django project.
 My team uses pytest for testing and follows PEP 8.
 We deploy to AWS using Docker containers.
-```
+
+```text
 
 Now future coding questions automatically consider your stack.
 
@@ -272,19 +310,23 @@ Set persistent preferences in Settings:
 
 **"What would you like ChatGPT to know about you?"**
 ```
+
 I'm a senior product manager at a B2B SaaS company.
 I prefer concise answers with bullet points.
-When I ask for feedback, be direct—don't sugarcoat.
+When I ask for feedback, be direct - don't sugarcoat.
 I value data and examples over theory.
-```
+
+```text
 
 **"How would you like ChatGPT to respond?"**
 ```
+
 Start with the bottom line, then provide details.
 Use tables for comparisons.
 Flag assumptions you're making.
 If my question is ambiguous, ask a clarifying question.
-```
+
+```text
 
 ### GPTs (Custom ChatGPT Configurations)
 For repeated tasks, create a GPT with:
@@ -302,8 +344,10 @@ Example: A "Code Reviewer" GPT pre-configured with your style guide.
 ChatGPT's training has a cutoff date. For current information:
 
 ```
+
 Search the web for [recent topic] and summarize what you find.
-```
+
+```text
 
 Or explicitly enable browsing in your prompt.
 
@@ -311,30 +355,37 @@ Or explicitly enable browsing in your prompt.
 ChatGPT can invent sources. If you need real citations:
 
 ```
+
 Only cite sources you can verify exist. If you're uncertain about
 a source, say "I believe there may be a source on this, but I
 cannot verify the exact reference."
-```
+
+```text
 
 ### Pitfall 3: Verbose Defaults
 GPT models can be wordy. For concise output:
 
 ```
+
 Be concise. Use bullet points. No preamble or conclusions.
 Just the answer.
-```
+
+```text
 
 ### Pitfall 4: Lost Context in Long Chats
 Long conversations can cause the model to "forget" earlier context.
 
 **Fix:** Periodically summarize:
 ```
+
 Let me recap our decisions so far:
+
 1. [Decision A]
 2. [Decision B]
 
 Correct any errors, then we'll continue.
-```
+
+```text
 
 ---
 
@@ -342,6 +393,7 @@ Correct any errors, then we'll continue.
 
 ### Technical Writing Template
 ```
+
 Write [document type] about [topic].
 
 **Audience:** [Who will read this]
@@ -350,44 +402,55 @@ Write [document type] about [topic].
 **Length:** [Word count or section count]
 
 **Must include:**
+
 - [Required element 1]
 - [Required element 2]
 
 **Avoid:**
+
 - [Thing to exclude]
-```
+
+```text
 
 ### Problem-Solving Template
 ```
+
 Help me solve this problem: [describe problem]
 
 **Context:**
+
 - [Relevant background]
 - [What I've tried]
 - [Constraints]
 
 **Please:**
+
 1. Confirm you understand the problem
 2. Identify the core issue
 3. Propose 2-3 approaches
 4. Recommend one with reasoning
-```
+
+```text
 
 ### Review/Feedback Template
 ```
+
 Review this [document/code/plan] and provide feedback.
 
 **Focus areas:**
+
 - [Specific aspect 1]
 - [Specific aspect 2]
 
 **Feedback format:**
+
 - What's working well (brief)
 - What needs improvement (detailed)
 - Priority ranking of fixes
 
 Be direct and specific. I want to improve, not be reassured.
-```
+
+```text
 
 ---
 
@@ -417,6 +480,6 @@ Be direct and specific. I want to improve, not be reassured.
 
 ---
 
-*Last updated: December 2025*
+*Last updated: June 2026*
 
-*Sources verified: All hyperlinks validated December 2025*
+*Sources verified: All hyperlinks validated June 2026*

--- a/docs/practical-examples-claude.md
+++ b/docs/practical-examples-claude.md
@@ -1,7 +1,8 @@
 # Practical Prompting: Claude
-## Real-World Examples for Anthropic's Claude (December 2025)
 
-> **"Claude 4.x models respond well to clear, explicit instructions. Being specific about your desired output can help enhance results."** — [Anthropic](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices)
+## Real-World Examples for Anthropic's Claude (June 2026)
+
+> **"Current Claude models respond well to clear, explicit instructions. Being specific about your desired output can help enhance results."** - [Anthropic](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices)
 
 ---
 
@@ -9,20 +10,24 @@
 
 **What it is:** Anthropic's conversational AI, available via claude.ai (consumer) and API (developers).
 
-**Current models (Dec 2025):**
-- **Claude 4 Opus (4.5)** — Most capable, long-horizon reasoning
-- **Claude 4 Sonnet (4.5)** — Balanced capability and speed
-- **Claude 4 Haiku (4.5)** — Fast and efficient
+**Current models (June 2026):**
+
+- **Claude Fable 5** - Most capable, frontier reasoning
+- **Claude Opus 4.8** - Current flagship default, long-horizon reasoning
+- **Claude Sonnet 4.6** - Balanced capability and speed
+- **Claude Haiku 4.5** - Fast and efficient
 
 **Key strengths:**
-- Long context windows (200K tokens)
+
+- Long context windows (up to 1M tokens on Opus and Sonnet; 200K on Haiku)
 - Excellent document analysis
 - Strong reasoning and nuance
 - Safety-conscious design
 - Projects feature for persistent context
 
 **Official Resources:**
-- [Claude Prompt Engineering Overview](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview) *(redirects to platform.claude.com)*
+
+- [Claude Prompt Engineering Overview](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/overview) *(redirects to platform.claude.com)*
 - [Claude 4 Best Practices](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices)
 - [Anthropic Interactive Tutorial](https://github.com/anthropics/prompt-eng-interactive-tutorial)
 
@@ -32,10 +37,10 @@
 
 Claude has distinct characteristics compared to other LLMs:
 
-1. **User messages carry more weight** — Claude places more emphasis on user messages than system prompts
-2. **Precise instruction following** — Claude 4.x follows instructions very literally
-3. **Ask for "above and beyond" explicitly** — Previous Claude versions added helpful extras; Claude 4.x requires you to request this
-4. **Parallel tool execution** — Claude 4.5 Sonnet is aggressive about parallelizing operations
+1. **User messages carry more weight** - Claude places more emphasis on user messages than system prompts
+2. **Precise instruction following** - Current Claude models follow instructions very literally
+3. **Ask for "above and beyond" explicitly** - Previous Claude versions added helpful extras; current Claude models require you to request this
+4. **Parallel tool execution** - Claude Sonnet 4.6 is aggressive about parallelizing operations
 
 From [Anthropic's blog](https://claude.com/blog/best-practices-for-prompt-engineering):
 > *"Breaking large tasks into smaller, discrete chunks remains valuable because it helps the model focus on doing its best work within a specific set of requirements."*
@@ -44,17 +49,19 @@ From [Anthropic's blog](https://claude.com/blog/best-practices-for-prompt-engine
 
 ## Example 1: Long Document Analysis
 
-Claude excels at analyzing long documents (up to 200K tokens).
+Claude excels at analyzing long documents (up to 1M tokens on Opus and Sonnet; 200K on Haiku).
 
 ### Basic Prompt
-```
+
+```text
 Summarize this document.
 
 [paste long document]
 ```
 
 ### Better Prompt
-```
+
+```text
 I'm going to share a long document. After reading it completely, please:
 
 1. **Executive Summary** (3-4 sentences): What is this document about and what's the main conclusion?
@@ -79,7 +86,8 @@ I'm going to share a long document. After reading it completely, please:
 ## Example 2: Code Generation with Testing
 
 ### The Prompt
-```
+
+```text
 Write a Python function that validates email addresses.
 
 Requirements:
@@ -97,8 +105,9 @@ Use pytest style for tests.
 ```
 
 **Why this works for Claude:**
+
 - Explicit output format (tuple type)
-- Specific request for tests (Claude 4.x won't add these unless asked)
+- Specific request for tests (current Claude models won't add these unless asked)
 - Clear structure for what comes after the main code
 
 ---
@@ -108,10 +117,12 @@ Use pytest style for tests.
 Claude excels at showing its reasoning process.
 
 ### The Task
+
 Evaluate a business decision.
 
 ### The Prompt
-```
+
+```text
 Help me evaluate whether to build vs. buy a CRM system.
 
 Context:
@@ -157,7 +168,8 @@ Claude Projects let you upload documents that persist across conversations.
 **Project: Technical Writing Assistant**
 
 **Project Instructions (Custom System Prompt):**
-```
+
+```text
 You are a technical writing assistant for our API documentation.
 
 Key guidelines:
@@ -175,7 +187,8 @@ When I share draft documentation, compare it against these standards.
 ```
 
 ### Using the Project
-```
+
+```text
 Review this API endpoint documentation. Flag any:
 1. Style guide violations
 2. Missing error handling examples
@@ -187,6 +200,7 @@ Review this API endpoint documentation. Flag any:
 ```
 
 **Why Projects are powerful:**
+
 - Documents persist (no re-uploading)
 - Custom instructions apply to all conversations
 - Great for consistent, domain-specific work
@@ -198,10 +212,12 @@ Review this API endpoint documentation. Flag any:
 Claude handles nuance and tone well.
 
 ### The Task
+
 Write a difficult email.
 
 ### The Prompt
-```
+
+```text
 Help me write a sensitive email.
 
 Situation: A team member's performance has declined over 3 months.
@@ -235,7 +251,8 @@ Label which is which and explain the key differences.
 ## Example 6: Multi-Turn Analysis
 
 ### Turn 1: Initial Analysis
-```
+
+```text
 Analyze this market research report. Before diving in, tell me:
 1. What type of document is this?
 2. What's its apparent purpose?
@@ -248,7 +265,8 @@ Analyze this market research report. Before diving in, tell me:
 ```
 
 ### Turn 2: Directed Deep Dive
-```
+
+```text
 Good analysis. Now focus on Section 3 (Market Trends).
 
 For each trend identified:
@@ -258,7 +276,8 @@ For each trend identified:
 ```
 
 ### Turn 3: Synthesis
-```
+
+```text
 Based on our analysis, draft a 1-page executive brief that:
 - Summarizes the trustworthy findings
 - Flags areas needing more research
@@ -274,7 +293,8 @@ Based on our analysis, draft a 1-page executive brief that:
 Claude can create interactive artifacts (code, documents, diagrams).
 
 ### The Prompt
-```
+
+```text
 Create an interactive React component that visualizes a decision tree.
 
 Requirements:
@@ -287,6 +307,7 @@ Include sample JSON data for a "hiring decision" tree.
 ```
 
 **Artifact types Claude can create:**
+
 - React components
 - HTML/CSS/JS pages
 - SVG diagrams
@@ -301,7 +322,7 @@ Include sample JSON data for a "hiring decision" tree.
 
 Claude responds well to XML-style delimiters:
 
-```
+```text
 <context>
 Background information about the task
 </context>
@@ -322,7 +343,7 @@ The actual task to perform
 
 ### Asking for Self-Critique
 
-```
+```text
 After completing the task, add a section called "Self-Assessment":
 - What assumptions did you make?
 - What's the weakest part of this response?
@@ -333,7 +354,7 @@ After completing the task, add a section called "Self-Assessment":
 
 Claude tends to be appropriately uncertain. Leverage this:
 
-```
+```text
 For each claim in your response, indicate your confidence:
 - HIGH: Well-established, widely agreed upon
 - MEDIUM: Generally accepted but with some debate
@@ -348,18 +369,18 @@ If LOW on something important, suggest how to verify.
 
 ### Pitfall 1: Expecting Unsolicited Extras
 
-Claude 4.x follows instructions precisely. If you want comprehensive treatment:
+Current Claude models follow instructions precisely. If you want comprehensive treatment:
 
-```
+```text
 ❌ "Explain machine learning"
    (Gets a basic explanation)
 
 ✅ "Explain machine learning comprehensively, including:
-   - Core concepts
-   - Types (supervised, unsupervised, reinforcement)
-   - Common algorithms for each type
-   - Real-world applications
-   - Current limitations and challenges"
+ - Core concepts
+ - Types (supervised, unsupervised, reinforcement)
+ - Common algorithms for each type
+ - Real-world applications
+ - Current limitations and challenges"
    (Gets thorough coverage)
 ```
 
@@ -367,7 +388,7 @@ Claude 4.x follows instructions precisely. If you want comprehensive treatment:
 
 Claude does better with focused tasks:
 
-```
+```text
 ❌ "Analyze this data, create visualizations, write a report,
    and suggest action items all in one response"
 
@@ -380,9 +401,9 @@ Claude does better with focused tasks:
 
 ### Pitfall 3: Not Using the Long Context
 
-Claude can handle 200K tokens. Use it:
+Claude can handle up to 1M tokens (Opus and Sonnet; 200K on Haiku). Use it:
 
-```
+```text
 Instead of:
 "Here's a summary of our codebase..."
 
@@ -400,7 +421,8 @@ For recurring tasks, set up a Project instead of re-uploading context each time.
 ## Prompt Templates for Claude
 
 ### Analysis Template
-```
+
+```text
 <context>
 [Background/situation description]
 </context>
@@ -426,7 +448,8 @@ Structure your response as:
 ```
 
 ### Writing Template
-```
+
+```text
 <context>
 Purpose: [Why this is being written]
 Audience: [Who will read it]
@@ -451,7 +474,8 @@ Before finalizing, verify:
 ```
 
 ### Problem-Solving Template
-```
+
+```text
 <problem>
 [Clear description of the problem]
 </problem>
@@ -489,8 +513,8 @@ Please:
 | Need reasoning shown | "Think through this step by step, showing your work" |
 | Want alternatives | "Provide 3 approaches with trade-offs for each" |
 | Tone matters | Explicitly specify tone with examples |
-| Parallel operations | Claude 4.5 Sonnet parallelizes automatically—design for it |
-| Long content | Use full 200K context window |
+| Parallel operations | Claude Sonnet 4.6 parallelizes automatically - design for it |
+| Long content | Use full 1M context window (Opus and Sonnet; 200K on Haiku) |
 
 ---
 
@@ -498,7 +522,7 @@ Please:
 
 | Resource | Description |
 |----------|-------------|
-| [Claude Prompt Engineering](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview) | Official documentation |
+| [Claude Prompt Engineering](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/overview) | Official documentation |
 | [Claude 4 Best Practices](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices) | Model-specific guidance |
 | [Context Engineering Guide](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) | Advanced context management |
 | [Interactive Tutorial](https://github.com/anthropics/prompt-eng-interactive-tutorial) | Hands-on practice |
@@ -506,6 +530,6 @@ Please:
 
 ---
 
-*Last updated: December 2025*
+*Last updated: June 2026*
 
-*Sources verified: All hyperlinks validated December 2025*
+*Sources verified: All hyperlinks validated June 2026*

--- a/docs/practical-examples-copilot.md
+++ b/docs/practical-examples-copilot.md
@@ -1,7 +1,8 @@
 # Practical Prompting: Microsoft 365 Copilot
-## Real-World Examples for M365 Copilot (December 2025)
 
-> **"Copilot doesn't work like a search engine. You get the best results when you use clear instructions, provide sources, and include specific context and format."** — [Microsoft](https://www.armanino.com/articles/microsoft-365-copilot-success-guide/)
+## Real-World Examples for M365 Copilot (June 2026)
+
+> **"Copilot doesn't work like a search engine. You get the best results when you use clear instructions, provide sources, and include specific context and format."** - [Microsoft](https://www.armanino.com/articles/microsoft-365-copilot-success-guide/)
 
 ---
 
@@ -9,15 +10,17 @@
 
 **What it is:** Microsoft's AI assistant integrated across Microsoft 365 apps (Word, Excel, PowerPoint, Outlook, Teams).
 
-**Key difference from other LLMs:** Copilot works with YOUR data—emails, documents, calendars, Teams chats—within your Microsoft 365 tenant.
+**Key difference from other LLMs:** Copilot works with YOUR data - emails, documents, calendars, Teams chats - within your Microsoft 365 tenant.
 
 **Key strengths:**
+
 - Deep integration with Microsoft 365 apps
 - Access to your organizational data
 - Enterprise security and compliance
 - Context-aware within each application
 
 **Official Resources:**
+
 - [Microsoft Learn: Craft Effective Prompts](https://learn.microsoft.com/en-us/training/paths/craft-effective-prompts-copilot-microsoft-365/)
 - [Microsoft Copilot Prompts Gallery](https://m365.cloud.microsoft/copilot-prompts)
 - [Azure Copilot Prompting Guide](https://learn.microsoft.com/en-us/azure/copilot/write-effective-prompts)
@@ -43,21 +46,23 @@ From [Microsoft's guidance](https://sharepointdesignworks.com/the-hidden-power-o
 
 ---
 
-## Example 1: Word — Document Drafting
+## Example 1: Word - Document Drafting
 
 ### Basic Prompt (Gets Generic Results)
-```
+
+```text
 Write a project proposal.
 ```
 
 ### Better Prompt (Gets Useful Results)
-```
+
+```text
 Draft a project proposal for migrating our CRM to Dynamics 365.
 
 Context:
 - Audience: IT leadership and Finance
 - Purpose: Request budget approval
-- Timeline: Implementation in Q2 2026
+- Timeline: Implementation in Q4 2026
 
 Source: Use details from /IT Strategy 2025.docx and the vendor quote in my recent emails from Microsoft.
 
@@ -74,19 +79,22 @@ Length: 2-3 pages
 ```
 
 **Why this works:**
+
 - Specific goal and audience
 - Points to actual source documents
 - Clear structure expectations
 
 ---
 
-## Example 2: Excel — Data Analysis
+## Example 2: Excel - Data Analysis
 
 ### The Task
+
 Analyze sales data and create insights.
 
 ### The Prompt (In Excel with Copilot)
-```
+
+```text
 Analyze this sales data and tell me:
 
 1. Which product category has the highest revenue?
@@ -103,7 +111,8 @@ Summarize your findings in 3 bullet points I can share with leadership.
 ```
 
 ### Formula Help
-```
+
+```text
 Create a formula that:
 - Calculates commission at 5% of sales in column C
 - But only if the salesperson in column A is "Senior"
@@ -115,10 +124,11 @@ Explain the formula so I can modify it later.
 
 ---
 
-## Example 3: Outlook — Email Management
+## Example 3: Outlook - Email Management
 
 ### Summarizing Email Threads
-```
+
+```text
 Summarize this email thread.
 
 Focus on:
@@ -131,7 +141,8 @@ Format as bullet points I can quickly scan.
 ```
 
 ### Drafting Responses
-```
+
+```text
 Draft a reply to this email that:
 - Confirms I received the request
 - Sets expectations: I'll respond fully by Friday
@@ -141,7 +152,8 @@ Draft a reply to this email that:
 ```
 
 ### Meeting Preparation
-```
+
+```text
 Look at my calendar for tomorrow and the related email threads.
 
 Create a prep brief for each meeting:
@@ -153,10 +165,11 @@ Create a prep brief for each meeting:
 
 ---
 
-## Example 4: PowerPoint — Presentation Creation
+## Example 4: PowerPoint - Presentation Creation
 
 ### From Scratch
-```
+
+```text
 Create a presentation about our Q4 marketing results.
 
 Source: Use data from /Q4 Marketing Report.xlsx
@@ -177,7 +190,8 @@ For each data slide, suggest a chart type that best represents the information.
 ```
 
 ### From Document
-```
+
+```text
 Create a presentation from /Project Alpha Proposal.docx
 
 Condense the 10-page document into 8 slides:
@@ -193,10 +207,11 @@ Keep key statistics and quotes. Suggest images for each slide.
 
 ---
 
-## Example 5: Teams — Meeting Intelligence
+## Example 5: Teams - Meeting Intelligence
 
 ### Pre-Meeting
-```
+
+```text
 I have a meeting with the Contoso team in 30 minutes.
 
 From my emails and our Teams chat history with them:
@@ -208,7 +223,8 @@ Give me 3 talking points to prepare.
 ```
 
 ### Post-Meeting Summary
-```
+
+```text
 Summarize the meeting we just had.
 
 Structure:
@@ -221,7 +237,8 @@ Format this so I can paste directly into the Teams channel.
 ```
 
 ### Chat Catch-Up
-```
+
+```text
 I've been away from this Teams channel for a week.
 
 Give me:
@@ -236,7 +253,8 @@ Give me:
 ## Example 6: Cross-App Workflows
 
 ### Finding Information Across M365
-```
+
+```text
 Find all documents and emails from the last month about the "Website Redesign" project.
 
 Summarize:
@@ -249,7 +267,8 @@ Create a single summary I can share with my manager who needs a quick update.
 ```
 
 ### Research Task
-```
+
+```text
 Our competitor Contoso just launched a new product.
 
 Search my emails and Teams for any mentions of Contoso.
@@ -266,27 +285,31 @@ Compile:
 ## Example 7: Specifying Sources (Critical)
 
 ### Good: Specific File References
-```
+
+```text
 Using the data in /Sales Q4 2024.xlsx and the template in /Report Template.docx,
 create a quarterly sales report.
 ```
 
 ### Good: Specific Email Context
-```
+
+```text
 Based on the email thread with subject "Budget Approval - Project Alpha"
 from last week, draft a follow-up email.
 ```
 
 ### Good: Limiting Scope
-```
+
+```text
 Looking only at Teams messages from the #marketing channel in the past 2 weeks,
 summarize the campaign performance discussions.
 ```
 
 ### Bad: No Source Specified
-```
+
+```text
 ❌ "Summarize our marketing performance"
-   (Copilot searches everything—slow and potentially irrelevant)
+   (Copilot searches everything - slow and potentially irrelevant)
 
 ❌ "What did we decide about the budget?"
    (Which budget? Which meeting? Which team?)
@@ -302,7 +325,7 @@ From [Microsoft's guidance](https://regoconsulting.com/mastering-microsoft-copil
 
 > *"If the first result isn't perfect, build on the existing prompt rather than deleting and starting over."*
 
-```
+```text
 Initial: "Create a project timeline"
 ↓
 Refinement: "Make the timeline show dependencies between tasks"
@@ -313,7 +336,8 @@ Refinement: "Change the format to a Gantt chart style"
 ```
 
 ### Include Your Role
-```
+
+```text
 I'm a project manager preparing for a steering committee meeting.
 
 [Rest of prompt]
@@ -322,7 +346,8 @@ I'm a project manager preparing for a steering committee meeting.
 This helps Copilot calibrate the level of detail and focus.
 
 ### Set Communication Style
-```
+
+```text
 Write this in a style that is:
 - Professional but conversational
 - Direct without being curt
@@ -336,7 +361,7 @@ Write this in a style that is:
 
 ### Pitfall 1: Treating It Like a Search Engine
 
-```
+```text
 ❌ "What's in my emails?"
 
 ✅ "Find emails from last week about the Henderson contract
@@ -345,24 +370,24 @@ Write this in a style that is:
 
 ### Pitfall 2: Not Specifying Sources
 
-```
+```text
 ❌ "Create a report on Q4 sales"
 
 ✅ "Create a report on Q4 sales using:
-   - Data from /Sales Data Q4.xlsx
-   - Template from /Quarterly Report Template.docx
-   - Context from the December sales meeting in Teams"
+ - Data from /Sales Data Q4.xlsx
+ - Template from /Quarterly Report Template.docx
+ - Context from the December sales meeting in Teams"
 ```
 
 ### Pitfall 3: Vague Expectations
 
-```
+```text
 ❌ "Make this better"
 
 ✅ "Revise this to:
-   - Be more concise (target 50% fewer words)
-   - Use active voice
-   - Start with the recommendation, then the reasoning"
+ - Be more concise (target 50% fewer words)
+ - Use active voice
+ - Start with the recommendation, then the reasoning"
 ```
 
 ### Pitfall 4: Skipping Education
@@ -378,7 +403,8 @@ Explore the [Copilot Prompts Gallery](https://m365.cloud.microsoft/copilot-promp
 ## Prompt Templates for Copilot
 
 ### Document Template
-```
+
+```text
 Create a [document type] about [topic].
 
 Source: [specific files/emails]
@@ -398,7 +424,8 @@ Format:
 ```
 
 ### Analysis Template
-```
+
+```text
 Analyze [data/content] from [specific source].
 
 Questions to answer:
@@ -413,7 +440,8 @@ Then provide: [recommendations/next steps/summary]
 ```
 
 ### Communication Template
-```
+
+```text
 Write [communication type] to [recipient].
 
 Context: [Background they need to know]
@@ -434,6 +462,7 @@ Constraints:
 ## App-Specific Quick Commands
 
 ### Word
+
 | Task | Prompt Start |
 |------|--------------|
 | New document | "Draft a [type] about..." |
@@ -442,6 +471,7 @@ Constraints:
 | Expand | "Add more detail about [section]" |
 
 ### Excel
+
 | Task | Prompt Start |
 |------|--------------|
 | Analyze | "What trends do you see in this data?" |
@@ -450,6 +480,7 @@ Constraints:
 | Visualize | "Create a chart showing..." |
 
 ### PowerPoint
+
 | Task | Prompt Start |
 |------|--------------|
 | Create | "Create a presentation about..." |
@@ -458,6 +489,7 @@ Constraints:
 | Design | "Suggest a better layout for..." |
 
 ### Outlook
+
 | Task | Prompt Start |
 |------|--------------|
 | Summarize | "Summarize this thread" |
@@ -466,6 +498,7 @@ Constraints:
 | Find | "Find emails about..." |
 
 ### Teams
+
 | Task | Prompt Start |
 |------|--------------|
 | Catch up | "What did I miss in..." |
@@ -501,6 +534,6 @@ Constraints:
 
 ---
 
-*Last updated: December 2025*
+*Last updated: June 2026*
 
-*Sources verified: All hyperlinks validated December 2025*
+*Sources verified: All hyperlinks validated June 2026*

--- a/docs/practical-examples-gemini.md
+++ b/docs/practical-examples-gemini.md
@@ -1,7 +1,8 @@
 # Practical Prompting: Google Gemini
-## Real-World Examples for Google's Gemini (December 2025)
 
-> **"Be precise and direct. State your goal clearly and concisely. Avoid unnecessary or overly persuasive language."** — [Google AI](https://ai.google.dev/gemini-api/docs/prompting-strategies)
+## Real-World Examples for Google's Gemini (June 2026)
+
+> **"Be precise and direct. State your goal clearly and concisely. Avoid unnecessary or overly persuasive language."** - [Google AI](https://ai.google.dev/gemini-api/docs/prompting-strategies)
 
 ---
 
@@ -9,36 +10,40 @@
 
 **What it is:** Google's multimodal AI, available via Gemini app, Google Workspace, and API.
 
-**Current models (Dec 2025):**
-- **Gemini 3** — Latest flagship (November 2025), enhanced instruction understanding
-- **Gemini 2.5 Pro** — Previous flagship, excellent reasoning
-- **Gemini 2.5 Flash** — Fast and efficient, good for image generation
+**Current models (June 2026):**
+
+- **Gemini 3.5 Pro** - Flagship (~2M context, Deep Think), enhanced instruction understanding
+- **Gemini 3.5 Flash** - Fast and efficient (1M context), high-volume tasks
+- **Gemini 2.5 Pro** - Previous flagship, excellent reasoning
 
 **Key strengths:**
+
 - Native multimodal (text, images, audio, video)
 - Deep Google Workspace integration
 - Strong at following complex instructions
 - Excellent at coding tasks
 
 **Official Resources:**
+
 - [Gemini Prompt Design Strategies](https://ai.google.dev/gemini-api/docs/prompting-strategies)
 - [Gemini for Workspace Guide](https://workspace.google.com/learning/content/gemini-prompt-guide)
 - [Google's Prompt Engineering Guide (PDF)](https://services.google.com/fh/files/misc/gemini-for-google-workspace-prompting-guide-101.pdf)
 
 ---
 
-## The Gemini 3 Mindset
+## The Gemini 3.5 Mindset
 
-**Big change in November 2025:** Gemini 3 is smarter about understanding intent. Elaborate prompts from Gemini 2.x are often unnecessary now.
+**Current generation:** Gemini 3.5 is smarter about understanding intent. Elaborate prompts from Gemini 2.x are often unnecessary now.
 
 From [Google's documentation](https://ai.google.dev/gemini-api/docs/prompting-strategies):
 
-> *"By default, Gemini 3 provides direct and efficient answers. If you need a more conversational or detailed response, you must explicitly request it."*
+> *"By default, Gemini 3.5 provides direct and efficient answers. If you need a more conversational or detailed response, you must explicitly request it."*
 
-**Three principles for Gemini 3:**
-1. **Clarity first** — State exactly what you want
-2. **Less is often more** — Don't over-engineer prompts
-3. **Multimodal is native** — Treat images/audio/video as first-class inputs
+**Three principles for Gemini 3.5:**
+
+1. **Clarity first** - State exactly what you want
+2. **Less is often more** - Don't over-engineer prompts
+3. **Multimodal is native** - Treat images/audio/video as first-class inputs
 
 ---
 
@@ -47,12 +52,14 @@ From [Google's documentation](https://ai.google.dev/gemini-api/docs/prompting-st
 Gemini in Gmail can draft, summarize, and refine emails.
 
 ### Basic Prompt
-```
+
+```text
 Write a follow-up email.
 ```
 
 ### Better Prompt (In Gmail's "Help me write")
-```
+
+```text
 Write a follow-up email to a client.
 
 Context:
@@ -65,17 +72,19 @@ Length: 3 short paragraphs
 Include: Link to our pricing page (I'll add)
 ```
 
-**Why this works:** Gemini in Workspace knows the app context—you're in Gmail, so it formats as an email. Adding specifics guides the content.
+**Why this works:** Gemini in Workspace knows the app context - you're in Gmail, so it formats as an email. Adding specifics guides the content.
 
 ---
 
 ## Example 2: Document Analysis (Google Docs)
 
 ### The Task
+
 Analyze a lengthy report in Google Docs.
 
 ### The Prompt (Using Gemini in Docs)
-```
+
+```text
 @doc Summarize this document for someone who has 5 minutes.
 
 Structure as:
@@ -87,7 +96,8 @@ Structure as:
 ```
 
 ### Follow-Up
-```
+
+```text
 Now create an executive summary paragraph I can paste at the top of the document. Keep it under 100 words.
 ```
 
@@ -100,7 +110,8 @@ Now create an executive summary paragraph I can paste at the top of the document
 Gemini treats images, audio, and video as equal inputs.
 
 ### Image Analysis
-```
+
+```text
 [Upload image of a whiteboard with diagrams]
 
 This is a photo of our architecture planning session.
@@ -113,7 +124,8 @@ Please:
 ```
 
 ### Video Analysis
-```
+
+```text
 [Upload video of a presentation]
 
 Watch this 10-minute presentation and provide:
@@ -124,7 +136,8 @@ Watch this 10-minute presentation and provide:
 ```
 
 ### Image + Text Combined
-```
+
+```text
 [Upload product photo]
 
 Write a product description for this item.
@@ -140,10 +153,12 @@ Length: 150-200 words
 ## Example 4: Spreadsheet Analysis (Google Sheets)
 
 ### The Task
+
 Analyze sales data in Sheets.
 
 ### The Prompt (In Sheets with Gemini)
-```
+
+```text
 @sheet Analyze this sales data.
 
 Questions to answer:
@@ -159,7 +174,8 @@ Present findings as:
 ```
 
 ### Creating Formulas
-```
+
+```text
 Create a formula that:
 - Calculates the running total of column B
 - Highlights cells where the value is 20% above average
@@ -173,10 +189,12 @@ Explain what the formula does.
 ## Example 5: Code Generation
 
 ### The Task
+
 Generate code for a specific framework.
 
 ### The Prompt
-```
+
+```text
 Write a Python function using FastAPI that:
 1. Accepts a JSON payload with user data
 2. Validates required fields (name, email, age)
@@ -198,10 +216,11 @@ Follow Google's Python style guide.
 
 ## Example 6: Structured Output Control
 
-Gemini 3 excels at producing structured output.
+Gemini 3.5 excels at producing structured output.
 
 ### JSON Output
-```
+
+```text
 Analyze this customer feedback and return structured data.
 
 Feedback: "The app crashes every time I try to upload a photo. This has been happening for a week. Otherwise love the product!"
@@ -219,7 +238,8 @@ Return as JSON with this exact schema:
 ```
 
 ### Table Output
-```
+
+```text
 Compare these three project management tools: Asana, Monday.com, Notion.
 
 Create a comparison table with columns:
@@ -238,7 +258,8 @@ From [Google's documentation](https://ai.google.dev/gemini-api/docs/prompting-st
 > *"Using examples to show the model a pattern to follow is more effective than using examples to show the model an anti-pattern to avoid."*
 
 ### Effective Few-Shot
-```
+
+```text
 Classify customer support tickets by priority.
 
 Examples:
@@ -262,34 +283,37 @@ Priority:
 
 ---
 
-## Gemini 3 Specific Tips
+## Gemini 3.5 Specific Tips
 
 ### Temperature Setting
+
 From [Google's guide](https://ai.google.dev/gemini-api/docs/prompting-strategies):
 
-> *"When using Gemini 3 models, Google strongly recommends keeping the temperature at its default value of 1.0. Changing the temperature may lead to unexpected behavior, particularly in complex mathematical or reasoning tasks."*
+> *"When using Gemini 3.5 models, Google strongly recommends keeping the temperature at its default value of 1.0. Changing the temperature may lead to unexpected behavior, particularly in complex mathematical or reasoning tasks."*
 
 Leave temperature at default unless you have a specific reason.
 
 ### Request Verbosity Explicitly
-Gemini 3 defaults to concise:
 
-```
+Gemini 3.5 defaults to concise:
+
+```text
 ❌ "Explain machine learning" → Gets brief answer
 
 ✅ "Explain machine learning in detail. Include:
-   - Historical context
-   - Key concepts with examples
-   - Current applications
-   - Future directions
+ - Historical context
+ - Key concepts with examples
+ - Current applications
+ - Future directions
 
    This is for a technical audience, so don't oversimplify."
 ```
 
 ### Consistent Delimiters
+
 Pick one format and stick with it:
 
-```
+```text
 Option A: XML tags
 <context>...</context>
 <task>...</task>
@@ -308,7 +332,8 @@ Don't mix styles in a single prompt.
 ## Workspace-Specific Prompts
 
 ### In Google Docs
-```
+
+```text
 Help me write
 - A proposal for [project name]
 - For audience: [executive team]
@@ -318,7 +343,8 @@ Help me write
 ```
 
 ### In Google Slides
-```
+
+```text
 Create a presentation outline on [topic]
 - 10 slides
 - Include: title slide, agenda, 6 content slides, summary, Q&A
@@ -327,7 +353,8 @@ Create a presentation outline on [topic]
 ```
 
 ### In Google Sheets
-```
+
+```text
 Help me create a formula that:
 - Looks up [value] in column A
 - Returns the corresponding value from column C
@@ -336,7 +363,8 @@ Help me create a formula that:
 ```
 
 ### In Gmail
-```
+
+```text
 Help me write a response to this email that:
 - Declines the meeting request
 - Suggests an alternative time next week
@@ -348,23 +376,23 @@ Help me write a response to this email that:
 
 ## Common Gemini Pitfalls
 
-### Pitfall 1: Over-Engineering Prompts for Gemini 3
+### Pitfall 1: Over-Engineering Prompts for Gemini 3.5
 
 If you wrote elaborate prompts for Gemini 2.x:
 
-```
+```text
 ❌ Long, detailed prompts with excessive context
 
 ✅ Clear, direct prompts with necessary context only
 ```
 
-Gemini 3 understands intent better—elaborate scaffolding often isn't needed.
+Gemini 3.5 understands intent better - elaborate scaffolding often isn't needed.
 
 ### Pitfall 2: Not Leveraging Multimodal
 
 Gemini is natively multimodal. Instead of describing:
 
-```
+```text
 ❌ "I have a chart showing revenue growth of 15% year over year..."
 
 ✅ [Upload the chart] "Analyze this revenue chart and summarize the trends"
@@ -374,8 +402,8 @@ Gemini is natively multimodal. Instead of describing:
 
 In Google Workspace, Gemini knows where you are:
 
-```
-❌ "Write an email" (in Gmail—redundant)
+```text
+❌ "Write an email" (in Gmail - redundant)
 
 ✅ "Write a meeting request for 3pm Tuesday about project Alpha"
    (Gemini knows it's an email, who you're emailing based on thread)
@@ -383,15 +411,15 @@ In Google Workspace, Gemini knows where you are:
 
 ### Pitfall 4: Not Specifying Output Format
 
-Gemini 3 defaults to concise. Be explicit:
+Gemini 3.5 defaults to concise. Be explicit:
 
-```
+```text
 ❌ "Summarize this document"
 
 ✅ "Summarize this document as:
-   - 1 paragraph overview
-   - 5 key bullet points
-   - A table of key metrics"
+ - 1 paragraph overview
+ - 5 key bullet points
+ - A table of key metrics"
 ```
 
 ---
@@ -399,7 +427,8 @@ Gemini 3 defaults to concise. Be explicit:
 ## Prompt Templates for Gemini
 
 ### Analysis Template
-```
+
+```text
 Analyze [content/data/image].
 
 Focus on:
@@ -415,7 +444,8 @@ Output format:
 ```
 
 ### Generation Template
-```
+
+```text
 Create [content type] about [topic].
 
 Requirements:
@@ -430,7 +460,8 @@ Structure as:
 ```
 
 ### Multimodal Template
-```
+
+```text
 [Upload file(s): image/video/audio]
 
 Please [action verb] this [content type].
@@ -456,7 +487,7 @@ Format response as:
 | Multiple files | Reference with @[filename] |
 | Need accuracy | "Cite sources" or "Only state what you can verify" |
 | Complex task | Break into steps, use "Let's think step by step" |
-| Gemini 3 | Simplify—it understands better |
+| Gemini 3.5 | Simplify - it understands better |
 
 ---
 
@@ -472,6 +503,6 @@ Format response as:
 
 ---
 
-*Last updated: December 2025*
+*Last updated: June 2026*
 
-*Sources verified: All hyperlinks validated December 2025*
+*Sources verified: All hyperlinks validated June 2026*

--- a/docs/prompt-engineering-fundamentals.md
+++ b/docs/prompt-engineering-fundamentals.md
@@ -1,5 +1,6 @@
 # Prompt Engineering Fundamentals
-## A Feynman-Style Guide to Talking with AI (December 2025)
+
+## A Feynman-Style Guide to Talking with AI (June 2026)
 
 > **"If you can't explain it simply, you don't understand it well enough."** - Richard Feynman
 
@@ -11,9 +12,9 @@ This guide explains prompt engineering the way Feynman would: simply, with analo
 
 **Prompt engineering is the art of giving clear instructions to AI.**
 
-Think of an LLM like a brilliant intern who has read the entire internet but has never worked at your company. They're smart, eager, and capable—but they need *your* guidance to be useful. The prompt is your job description, context, and task all rolled into one.
+Think of an LLM like a brilliant intern who has read the entire internet but has never worked at your company. They're smart, eager, and capable - but they need *your* guidance to be useful. The prompt is your job description, context, and task all rolled into one.
 
-> *"The best prompt isn't the longest or most complex. It's the one that achieves your goals reliably with the minimum necessary structure."* — [Anthropic](https://claude.com/blog/best-practices-for-prompt-engineering)
+> *"The best prompt isn't the longest or most complex. It's the one that achieves your goals reliably with the minimum necessary structure."* - [Anthropic](https://claude.com/blog/best-practices-for-prompt-engineering)
 
 ---
 
@@ -35,7 +36,7 @@ Every effective prompt has these components. Miss one, and you'll get disappoint
 
 Tell the AI *who* it should be for this task.
 
-```
+```text
 You are a senior Python developer who specializes in clean, readable code.
 ```
 
@@ -57,20 +58,20 @@ Be specific about the action. Vague tasks get vague results.
 
 Tell the AI exactly how to structure its response.
 
-```
+```text
 Respond in this format:
 - Summary: [2 sentences]
 - Key Points: [bullet list, max 5]
 - Recommendation: [1 sentence]
 ```
 
-**Pro tip from [Google](https://ai.google.dev/gemini-api/docs/prompting-strategies):** Use consistent delimiters—XML tags (`<context>...</context>`) or Markdown headers. Pick one style and stick with it.
+**Pro tip from [Google](https://ai.google.dev/gemini-api/docs/prompting-strategies):** Use consistent delimiters - XML tags (`<context>...</context>`) or Markdown headers. Pick one style and stick with it.
 
 ### 4. Constraints (What Are the Boundaries?)
 
 Set limits to focus the response.
 
-```
+```text
 - Maximum 100 words
 - Use simple language a 10-year-old would understand
 - Don't include technical jargon
@@ -85,7 +86,7 @@ Set limits to focus the response.
 
 The simplest approach. Give instructions without examples.
 
-```
+```text
 Translate the following English text to French: "Hello, how are you?"
 ```
 
@@ -95,7 +96,7 @@ Translate the following English text to French: "Hello, how are you?"
 
 Provide one example of what you want.
 
-```
+```text
 Convert the company name to its stock ticker.
 
 Example:
@@ -112,7 +113,7 @@ Ticker:
 
 Provide 3-5 examples to establish a pattern.
 
-```
+```text
 Classify the sentiment of these reviews:
 
 Review: "Absolutely loved it!" → Positive
@@ -122,25 +123,27 @@ Review: "It's okay, nothing special." → Neutral
 Review: "Would definitely buy again!" →
 ```
 
-**When to use:** Complex or domain-specific tasks. The model learns the pattern from your examples. [Research suggests](https://www.promptingguide.ai/techniques/fewshot) 3-5 examples is the sweet spot—more can cause overfitting.
+**When to use:** Complex or domain-specific tasks. The model learns the pattern from your examples. [Research suggests](https://www.promptingguide.ai/techniques/fewshot) 3-5 examples is the sweet spot - more can cause overfitting.
 
 ### Chain-of-Thought (CoT): Make It Think
 
 Add "Let's think step by step" or provide examples with reasoning steps.
 
 **Zero-shot CoT:**
-```
+
+```text
 How many r's are in "strawberry"? Let's think step by step.
 ```
 
 **Few-shot CoT:**
-```
+
+```text
 Q: If I have 3 apples and give away 1, then buy 4 more, how many do I have?
 A: Let's solve this step by step:
-   - Start with 3 apples
-   - Give away 1: 3 - 1 = 2 apples
-   - Buy 4 more: 2 + 4 = 6 apples
-   - Final answer: 6 apples
+ - Start with 3 apples
+ - Give away 1: 3 - 1 = 2 apples
+ - Buy 4 more: 2 + 4 = 6 apples
+ - Final answer: 6 apples
 
 Q: If I have 10 dollars, spend 3, and earn 7 more, how much do I have?
 A:
@@ -164,17 +167,19 @@ Most LLM interfaces have two types of prompts:
 | Set once, reused | Changes each interaction |
 
 **Example System Prompt:**
-```
+
+```text
 You are a helpful coding assistant. You write clean, well-commented Python code.
 You always explain your code after writing it. You never use deprecated functions.
 ```
 
 **Example User Prompt:**
-```
+
+```text
 Write a function that checks if a number is prime.
 ```
 
-**Best practice from [PromptLayer](https://blog.promptlayer.com/system-prompt-vs-user-prompt-a-comprehensive-guide-for-ai-prompts/):** Put static instructions in the system prompt, dynamic content in the user prompt. When unsure, prefer the user prompt—it's more portable across models.
+**Best practice from [PromptLayer](https://blog.promptlayer.com/system-prompt-vs-user-prompt-a-comprehensive-guide-for-ai-prompts/):** Put static instructions in the system prompt, dynamic content in the user prompt. When unsure, prefer the user prompt - it's more portable across models.
 
 **Model-specific note:** Claude places more emphasis on user messages than system prompts ([Nebuly](https://www.nebuly.com/blog/llm-system-prompt-vs-user-prompt)).
 
@@ -183,25 +188,29 @@ Write a function that checks if a number is prime.
 ## Common Mistakes (And Fixes)
 
 ### Mistake 1: Being Too Vague
-```
+
+```text
 ❌ "Help me write an email"
 ✅ "Write a professional 3-paragraph email declining a meeting invitation.
     Tone: polite but firm. Suggest rescheduling for next week."
 ```
 
 ### Mistake 2: Overloading with Instructions
-```
+
+```text
 ❌ [500 words of instructions for a simple task]
 ✅ Break into multiple prompts, or use a clear structure with headers
 ```
 
 ### Mistake 3: Not Iterating
+
 The first prompt rarely gives perfect results. Refine based on output.
 
-> *"Prompt engineering is inherently iterative. Start with an initial prompt, review the response, and refine."* — [OpenAI](https://help.openai.com/en/articles/10032626-prompt-engineering-best-practices-for-chatgpt)
+> *"Prompt engineering is inherently iterative. Start with an initial prompt, review the response, and refine."* - [OpenAI](https://help.openai.com/en/articles/10032626-prompt-engineering-best-practices-for-chatgpt)
 
 ### Mistake 4: Fighting the Model's Defaults
-If you want verbose output from a model trained to be concise, say so explicitly. Modern models like [Gemini 3](https://promptbuilder.cc/blog/gemini-3-prompting-playbook-november-2025) provide direct answers by default—request detail if you need it.
+
+If you want verbose output from a model trained to be concise, say so explicitly. Modern models like recent Gemini models provide direct answers by default - request detail if you need it.
 
 ---
 
@@ -219,7 +228,7 @@ If you want verbose output from a model trained to be concise, say so explicitly
 
 ## Quick Reference: Prompt Template
 
-```
+```text
 [ROLE]
 You are a [specific expertise] who [key characteristic].
 
@@ -247,7 +256,7 @@ Respond using:
 | Resource | Best For |
 |----------|----------|
 | [OpenAI Prompt Engineering Guide](https://platform.openai.com/docs/guides/prompt-engineering) | Official techniques, API users |
-| [Anthropic Prompt Engineering](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview) | Claude-specific, safety-focused |
+| [Anthropic Prompt Engineering](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/overview) | Claude-specific, safety-focused |
 | [Prompt Engineering Guide](https://www.promptingguide.ai/) | Comprehensive reference, all models |
 | [OpenAI Academy - Prompting](https://academy.openai.com/public/clubs/work-users-ynjqu/resources/prompting) | Beginners, ChatGPT users |
 | [Lakera's 2025 Guide](https://www.lakera.ai/blog/prompt-engineering-guide) | Security considerations |
@@ -256,14 +265,14 @@ Respond using:
 
 ## Key Takeaways
 
-1. **Clarity beats cleverness** — Simple, specific prompts outperform elaborate ones
-2. **Show, don't just tell** — Examples (few-shot) are powerful teachers
-3. **Structure matters** — Use consistent formatting and clear sections
-4. **Iterate always** — Your first prompt is your first draft, not your final product
-5. **Know your model** — Different LLMs respond differently to the same prompt
+1. **Clarity beats cleverness** - Simple, specific prompts outperform elaborate ones
+2. **Show, don't just tell** - Examples (few-shot) are powerful teachers
+3. **Structure matters** - Use consistent formatting and clear sections
+4. **Iterate always** - Your first prompt is your first draft, not your final product
+5. **Know your model** - Different LLMs respond differently to the same prompt
 
 ---
 
-*Last updated: December 2025*
+*Last updated: June 2026*
 
-*Sources verified: All hyperlinks validated December 2025*
+*Sources verified: All hyperlinks validated June 2026*

--- a/markdownlint.json
+++ b/markdownlint.json
@@ -25,5 +25,6 @@
   "MD032": true,
   "MD033": false,
   "MD036": false,
-  "MD041": true
+  "MD041": true,
+  "MD060": false
 }

--- a/segments/segment-1-identity-mindset-context/demos/anchor-trap-exercise.md
+++ b/segments/segment-1-identity-mindset-context/demos/anchor-trap-exercise.md
@@ -23,7 +23,7 @@ Before prompting any AI tool, draft your analysis below. Consider:
 
 ### Your Draft
 
-```
+```text
 Arguments FOR:
 -
 -
@@ -51,7 +51,7 @@ My confidence level (1-5):
 
 Open ChatGPT, Copilot, or Gemini and run this prompt:
 
-```
+```text
 You are a senior strategy consultant advising a mid-size robotics company.
 
 Company: Contoso Robotics

--- a/segments/segment-1-identity-mindset-context/demos/context-vs-no-context.md
+++ b/segments/segment-1-identity-mindset-context/demos/context-vs-no-context.md
@@ -13,7 +13,7 @@ Run both versions of the prompt below in the same AI tool. Compare the outputs t
 
 ## Version A: Bare Prompt (No Context)
 
-```
+```text
 Write a market analysis for our new product line.
 ```
 
@@ -34,7 +34,7 @@ The AI has almost nothing to work with. It will likely:
 
 ## Version B: Context-Rich Prompt
 
-```
+```text
 You are a senior market analyst advising Contoso Robotics on a strategic expansion.
 
 Company context:

--- a/segments/segment-1-identity-mindset-context/demos/identity-awareness-checklist.md
+++ b/segments/segment-1-identity-mindset-context/demos/identity-awareness-checklist.md
@@ -16,7 +16,7 @@ The same principle applies across every AI platform. Your identity is not just a
 
 ### Microsoft 365 Copilot
 
-| Factor | Work Account (mchen@contosorobotics.com) | Personal Account (mchen@outlook.com) |
+| Factor | Work Account (<mchen@contosorobotics.com>) | Personal Account (<mchen@outlook.com>) |
 |--------|------------------------------------------|--------------------------------------|
 | Email access | Contoso Robotics Exchange mailbox | Personal Outlook.com inbox |
 | File access | SharePoint, OneDrive for Business, Teams files | Personal OneDrive |
@@ -61,7 +61,7 @@ The same principle applies across every AI platform. Your identity is not just a
 
 ### Google Gemini
 
-| Factor | Google Workspace (mchen@contosorobotics.com) | Personal Google account |
+| Factor | Google Workspace (<mchen@contosorobotics.com>) | Personal Google account |
 |--------|-----------------------------------------------|------------------------|
 | Drive access | Contoso Shared Drives and team files | Personal Google Drive |
 | Gmail context | Contoso business email | Personal Gmail |

--- a/segments/segment-2-context-sculpting-technique/demos/few-shot-showdown.md
+++ b/segments/segment-2-context-sculpting-technique/demos/few-shot-showdown.md
@@ -2,7 +2,7 @@
 
 **Law 11 -- Few-Shot Examples:** Show the model what "good" looks like before asking it to produce.
 
-**Tool:** ChatGPT (GPT-4o or later) | **Time:** 10 minutes
+**Tool:** ChatGPT (GPT-5.x or any current model) | **Time:** 10 minutes
 
 ---
 

--- a/segments/segment-3-workflow-multimodal-security/demos/cross-reference-exercise.md
+++ b/segments/segment-3-workflow-multimodal-security/demos/cross-reference-exercise.md
@@ -16,7 +16,7 @@ Contoso Robotics is expanding into the European market. The compliance team need
 
 Send this exact prompt to ChatGPT, Claude, and Gemini in three separate sessions:
 
-```
+```text
 Contoso Robotics manufactures industrial warehouse automation robots
 and is preparing to sell in the European Union for the first time.
 

--- a/segments/segment-3-workflow-multimodal-security/demos/custom-instructions-lifecycle.md
+++ b/segments/segment-3-workflow-multimodal-security/demos/custom-instructions-lifecycle.md
@@ -32,7 +32,7 @@ Read through the instructions before pasting. Notice:
 
 Send this prompt to the project:
 
-```
+```text
 Write a one-page product announcement for our new RoboAssist Pro 3000
 warehouse automation robot. Target audience is logistics managers at
 mid-size distribution centers.
@@ -49,7 +49,7 @@ Save the response. Note:
 
 Send this follow-up in the same conversation:
 
-```
+```text
 Now create 3 social media posts promoting the same product for LinkedIn.
 ```
 
@@ -74,7 +74,7 @@ Read through v2 and compare to v1:
 
 Send the identical product announcement prompt:
 
-```
+```text
 Write a one-page product announcement for our new RoboAssist Pro 3000
 warehouse automation robot. Target audience is logistics managers at
 mid-size distribution centers.
@@ -82,7 +82,7 @@ mid-size distribution centers.
 
 Then the same follow-up:
 
-```
+```text
 Now create 3 social media posts promoting the same product for LinkedIn.
 ```
 

--- a/segments/segment-3-workflow-multimodal-security/demos/prompt-versioning-exercise.md
+++ b/segments/segment-3-workflow-multimodal-security/demos/prompt-versioning-exercise.md
@@ -19,7 +19,7 @@ Contoso Robotics department leads submit weekly status reports to CEO Maria Chen
 **Date:** 2026-01-15
 **Changelog:** Initial draft. Minimal guidance, no structure specified.
 
-```
+```text
 Write a weekly status report for my department.
 ```
 
@@ -32,7 +32,7 @@ Write a weekly status report for my department.
 **Date:** 2026-02-03
 **Changelog:** Added role assignment, explicit format requirements, and audience context. Addresses feedback that v1 outputs varied wildly in length and structure.
 
-```
+```text
 You are a department lead at Contoso Robotics, a mid-size robotics
 manufacturer in Austin, TX (500 employees, $120M revenue).
 
@@ -61,7 +61,7 @@ Constraints:
 **Date:** 2026-03-10
 **Changelog:** Added a concrete example report to anchor tone, specificity, and formatting. Addresses feedback that v2 outputs were structurally correct but lacked the right level of detail.
 
-```
+```text
 You are a department lead at Contoso Robotics, a mid-size robotics
 manufacturer in Austin, TX (500 employees, $120M revenue).
 

--- a/segments/segment-3-workflow-multimodal-security/knowledge/choose-an-agile-approach/includes/4-plan-work-azure-boards.md
+++ b/segments/segment-3-workflow-multimodal-security/knowledge/choose-an-agile-approach/includes/4-plan-work-azure-boards.md
@@ -49,7 +49,7 @@ Now's a good time to add members to your team. Although not required, if you'd l
 1. Enter the email address of the user you'd like to add, then select **Save**.
 1. Repeat the process for any other members you'd like to add.
 
-Mara adds entries for herself and her team members: *andy@tailspintoys.com*, *amita@tailspintoys.com*, *mara@tailspintoys.com*, and *tim@tailspintoys.com*.
+Mara adds entries for herself and her team members: *<andy@tailspintoys.com>*, *<amita@tailspintoys.com>*, *<mara@tailspintoys.com>*, and *<tim@tailspintoys.com>*.
 
 In practice, you might manage your team through an identity and access management service like Microsoft Entra ID, and set the appropriate permission levels for each team member. We'll point you to more resources at the end of this module.
 
@@ -112,7 +112,7 @@ When you create an Azure Boards project, you get an initial sprint called **Spri
 
 ### Assign tasks and set the iteration
 
-An _iteration_ is another name for a sprint.
+An *iteration* is another name for a sprint.
 
 You have an initial set of work items and a timeline for your first sprint. Here, you'll connect work items to your sprint and assign the tasks to yourself.
 

--- a/segments/segment-4-agentic-orchestration/data/contoso-agent-knowledge-base.md
+++ b/segments/segment-4-agentic-orchestration/data/contoso-agent-knowledge-base.md
@@ -63,7 +63,7 @@ Contoso Robotics is a mid-size robotics manufacturer headquartered in Austin, Te
 
 - Business hours: Monday through Friday, 7:00 AM to 7:00 PM Central Time
 - Response time: Within 4 business hours for critical issues, within 1 business day for standard requests
-- Channels: Phone (512-555-0100), email (support@contosorobotics.com), and the Contoso Support Portal
+- Channels: Phone (512-555-0100), email (<support@contosorobotics.com>), and the Contoso Support Portal
 
 **Premium Support** is available as an add-on ($3,000/unit/year):
 

--- a/segments/segment-4-agentic-orchestration/demos/checkpoint-rewind-exercise.md
+++ b/segments/segment-4-agentic-orchestration/demos/checkpoint-rewind-exercise.md
@@ -19,14 +19,14 @@ You will use Claude Code to attempt the refactor, observe it break something, an
 
 Open Claude Code in your project directory and examine the current state:
 
-```
+```text
 $ claude
 > What is the current structure of this project? List all source files and their line counts.
 ```
 
 Expected output (representative):
 
-```
+```text
 Project structure:
   src/
     routes.js        (1,247 lines)
@@ -42,7 +42,7 @@ Project structure:
 
 Claude Code creates checkpoints automatically before making changes. You can verify this:
 
-```
+```text
 > Show me the current checkpoint status.
 ```
 
@@ -52,7 +52,7 @@ You should see confirmation that checkpoint tracking is active. Every file modif
 
 Now ask Claude Code to perform the large refactor:
 
-```
+```text
 > Refactor src/routes.js into separate route modules:
 > - src/routes/auth.js (authentication endpoints)
 > - src/routes/inventory.js (inventory management endpoints)
@@ -75,13 +75,13 @@ Claude Code will begin making changes across multiple files. Watch the output as
 
 After the refactor completes, run the test suite:
 
-```
+```text
 > Run the test suite and show me the results.
 ```
 
 Expected output (representative):
 
-```
+```text
 FAIL tests/routes.test.js
   - Authentication middleware not applied to inventory routes (FAILED)
   - Database connection pool shared incorrectly across modules (FAILED)
@@ -102,13 +102,13 @@ Press `Esc` twice quickly (`Esc Esc`). Claude Code will show you the available c
 
 **Option B -- The /rewind command:**
 
-```
+```text
 > /rewind
 ```
 
 Claude Code will display a list of recent checkpoints:
 
-```
+```text
 Available checkpoints:
   [1] Before refactoring src/routes.js (3 minutes ago)
   [2] Before editing src/server.js (2 minutes ago)
@@ -123,13 +123,13 @@ Select checkpoint 1 to restore the codebase to its state before any refactoring 
 
 Confirm the codebase is back to its original state:
 
-```
+```text
 > Run the test suite again to confirm everything passes.
 ```
 
 Expected output:
 
-```
+```text
 PASS tests/routes.test.js
 
 Tests: 22 passed, 22 total
@@ -141,7 +141,7 @@ The codebase is exactly where it was before the refactor attempt. No work was lo
 
 Now try the refactor again, but this time ask Claude Code to preserve the middleware chain:
 
-```
+```text
 > Let's try the refactor again, but this time:
 > 1. Keep the middleware registration in server.js (do not move it into route modules)
 > 2. Extract only the route handler functions into separate modules

--- a/segments/segment-4-agentic-orchestration/demos/copilot-studio-agent.md
+++ b/segments/segment-4-agentic-orchestration/demos/copilot-studio-agent.md
@@ -25,19 +25,19 @@ A customer support agent for Contoso Robotics that can:
 ## Step 1: Create the Agent
 
 1. Navigate to [https://copilotstudio.microsoft.com](https://copilotstudio.microsoft.com).
-2. Select **Create** from the left navigation, then **New agent**.
-3. Fill in the agent details:
+2. On the **Home** page, in the describe-your-agent box, enter a description of what the agent should do. Copilot Studio provisions the agent and opens its **Overview** page.
+3. On the **Overview** page, refine the AI-generated details:
    - **Name:** Contoso Robotics Support Assistant
    - **Description:** Helps customers with product information, troubleshooting, and support requests for Contoso Robotics warehouse automation products.
    - **Instructions:** You are a friendly and knowledgeable customer support agent for Contoso Robotics. You help customers with product information about WarehouseBot Pro, WarehouseBot Lite, and LogiMover 500. You answer questions about pricing, specifications, warranty, and support policies. If you cannot answer a question, escalate to a human agent. Always be professional and concise.
-4. Select **Create**.
+4. Save your changes. (To skip the natural-language flow and fill in a form directly, use the manual "skip to configure" option on the Home page instead.)
 
 ## Step 2: Add the Knowledge Source
 
-1. In the agent editor, select **Knowledge** from the top navigation.
+1. In the agent editor, open the **Knowledge** page.
 2. Select **Add knowledge**.
-3. Choose **Files** as the source type.
-4. Upload the file `../data/contoso-agent-knowledge-base.md` (or copy its contents into a document that you upload).
+3. Choose **File upload** as the source type.
+4. Upload the file `../data/contoso-agent-knowledge-base.md` (or copy its contents into a document that you upload), then provide a name and description.
 5. Select **Add** to confirm.
 
 The agent will now use this document to ground its responses. When a customer asks about pricing, warranty terms, or product specs, the agent retrieves relevant passages from this knowledge base rather than generating answers from its training data alone.
@@ -48,7 +48,7 @@ Create three custom topics to handle the most common customer interactions.
 
 ### Topic 1: Product Information
 
-1. Select **Topics** from the top navigation, then **Add a topic** and choose **From blank**.
+1. Open the **Topics** page, select **Add a topic**, and choose **From blank**.
 2. Name the topic: **Product Information**
 3. Add these trigger phrases:
    - "Tell me about your products"
@@ -57,7 +57,7 @@ Create three custom topics to handle the most common customer interactions.
    - "How much does LogiMover cost"
    - "Compare your robot models"
 4. Add a **Message** node with the text: "I can help you with information about our product line. Let me look that up for you."
-5. Add a **Generative answers** node configured to search the uploaded knowledge base.
+5. Add a **Create generative answers** node configured to search the uploaded knowledge base.
 6. Save the topic.
 
 ### Topic 2: Troubleshooting
@@ -75,31 +75,28 @@ Create three custom topics to handle the most common customer interactions.
    - WarehouseBot Lite
    - LogiMover 500
 5. Add a **Question** node asking: "Please describe the issue you are experiencing."
-6. Add a **Generative answers** node to search the knowledge base for troubleshooting guidance.
+6. Add a **Create generative answers** node to search the knowledge base for troubleshooting guidance.
 7. Add a **Message** node: "If this does not resolve your issue, I can connect you with a support specialist."
 8. Save the topic.
 
 ### Topic 3: Escalation to Human Agent
 
-1. Add another topic from blank.
-2. Name the topic: **Escalate to Support**
-3. Add these trigger phrases:
-   - "Talk to a human"
-   - "I need to speak with someone"
-   - "Transfer me to support"
-   - "This is not helping"
-   - "Escalate my issue"
-4. Add a **Message** node: "I understand you would like to speak with a support specialist. Let me transfer you now."
-5. Add a **Transfer to agent** node (or a **Redirect** node to your organization's live agent system).
-6. Save the topic.
+Escalation is handled through the built-in **Escalate** system topic rather than a custom topic.
 
-## Step 4: Configure Conversation Starters
+1. On the **Topics** page, open the **System** tab and select the **Escalate** topic.
+2. Add a **Message** node: "I understand you would like to speak with a support specialist. Let me transfer you now."
+3. Add a transfer node via **Add node > Topic management > Transfer conversation**, then choose the **Transfer to agent** option (or **External phone number transfer**) for your organization's live agent system. If you have no live-agent hub, use **Go to another topic** with a support message and URL instead.
+4. Save the topic.
 
-1. Return to the agent **Settings** page.
-2. Under **Conversation starters**, add these suggestions that appear when a user first opens the chat:
+## Step 4: Configure Suggested Prompts
+
+1. Return to the agent **Overview** page.
+2. In the **Suggested prompts** section, select **Add suggested prompts** and add these:
    - "Tell me about WarehouseBot Pro"
    - "I need help troubleshooting my robot"
    - "What is your warranty policy?"
+
+Note: suggested prompts appear on the agent's welcome surface in Teams and Microsoft 365 Copilot. They do not show in the Copilot Studio test panel, so you will not see them while testing in Step 5.
 
 ## Step 5: Test the Agent
 
@@ -129,9 +126,9 @@ For this course exercise, testing in the built-in panel is sufficient.
 This agent was built using the Copilot Studio interface as it exists in early 2026. Here is what may change:
 
 - **Menu paths** may be renamed or reorganized in future updates
-- **Generative answers** configuration options may expand
+- **Create generative answers** configuration options may expand
 - **New channel options** (WhatsApp, Slack) may become available
-- **Model selection** (GPT-4.1, GPT-5, etc.) will change as new models ship
+- **Model selection** (the GPT models offered) will change as new models ship
 - **MCP integration** may replace or supplement some knowledge source patterns
 
 The design principles stay constant: define clear triggers, ground responses in authoritative knowledge, test with representative utterances, and provide an escalation path. When the UI changes, apply these principles to the new interface.

--- a/segments/segment-4-agentic-orchestration/demos/llm-personality-test.md
+++ b/segments/segment-4-agentic-orchestration/demos/llm-personality-test.md
@@ -66,7 +66,7 @@ Use the CSV rubric at `../data/contoso-llm-comparison-rubric.csv`. For each crit
 
 For each model:
 
-```
+```text
 Weighted Score = SUM(criterion_score * weight) / 100
 ```
 

--- a/segments/segment-4-agentic-orchestration/demos/subagent-orchestration.md
+++ b/segments/segment-4-agentic-orchestration/demos/subagent-orchestration.md
@@ -76,7 +76,7 @@ Claude Code will spawn three subagents, each working on its own task. You will s
 
 When subagents need to modify the same files, use git worktrees to give each agent its own working directory. This prevents merge conflicts during parallel execution.
 
-#### What Are Git Worktrees?
+#### What Are Git Worktrees
 
 A git worktree lets you check out the same branch (or different branches) into multiple directories simultaneously, all sharing the same `.git` history.
 


### PR DESCRIPTION
Pre-delivery freshen pass for the Wednesday O'Reilly session. Verified demo code runs and refreshed stale facts against current (June 2026) reality using MS Learn and vendor sources.

Content currency (HIGH-confidence, sourced):
- Copilot Studio demo: corrected 6 UI labels against MS Learn (Home/ Overview agent creation, File upload, Create generative answers node, Transfer conversation via Escalate system topic, Suggested prompts)
- README: replaced retired image models (DALL-E 3 -> GPT Image 2, Imagen 3 -> Imagen 4)
- Refreshed model names: Claude family (Fable 5/Opus 4.8/Sonnet 4.6/ Haiku 4.5) + 1M context, GPT-5.1 -> GPT-5.5, Gemini 3 -> Gemini 3.5, GPT-4 -> GPT-5.x in Warner's Law 23
- Updated docs.anthropic.com -> docs.claude.com links
- Re-stamped December 2025 / April 2026 dates to June 2026
- COURSE-PLAN: removed incorrect "in Foundry" from Copilot Studio demo

Formatting:
- markdownlint --fix across all content (spacing, code-fence languages)
- Removed all em dashes from authored content (per style guide)
- Disabled MD060 (cosmetic table-pipe rule, tables render fine)
- Added .markdownlintignore for node_modules

Code verified: weather MCP server boots clean, uses current SDK API. No code changes needed.

## Summary
- Lesson / segment touched:
- Learner outcome improved:
- Assets updated (docs, templates, demos, etc.):

## Testing
- [ ] `npm test`
- [ ] `node src/index.js`
- [ ] Other (list):

## Teaching Impact
- [ ] Demo instructions or screenshots included (if UX/content changed)
- [ ] Risks or caveats called out for facilitators
- [ ] Security / privacy reviewed per [SECURITY.md](../SECURITY.md)

> For urgent blockers or sensitive topics, ping Tim Warner (`tim@techtrainertim.com`).
